### PR TITLE
Correct Imagen shutdown dates and warn when a deprecated model is selected

### DIFF
--- a/docs/docs/plugins/input/google-genai.md
+++ b/docs/docs/plugins/input/google-genai.md
@@ -69,12 +69,12 @@ Generated images are cached under `~/.cache/tinct/generated/google-genai/`. Each
 | `gemini-3-pro-image-preview` | Nano Banana Pro — highest quality (~$0.134/image) |
 | `gemini-3.1-flash-image` | **Default.** Nano Banana 2, GA — fast, balanced quality (~$0.0672/image) |
 | `gemini-2.5-flash-image` | Nano Banana — cheapest Gemini image model (~$0.039/image) |
-| `imagen-4.0-ultra-generate-001` | Imagen 4 Ultra — _deprecated, shuts down 2026-08-17_ |
-| `imagen-4.0-generate-001` | Imagen 4 — _deprecated, shuts down 2026-08-17_ |
-| `imagen-4.0-fast-generate-001` | Imagen 4 Fast — _deprecated, shuts down 2026-08-17_ |
-| `imagen-3.0-generate-002` | Imagen 3 — _deprecated, shuts down 2026-08-17_ |
+| `imagen-4.0-ultra-generate-001` | Imagen 4 Ultra — _deprecated, earliest shutdown 2026-08-17_ |
+| `imagen-4.0-generate-001` | Imagen 4 — _deprecated, earliest shutdown 2026-08-17_ |
+| `imagen-4.0-fast-generate-001` | Imagen 4 Fast — _deprecated, earliest shutdown 2026-08-17_ |
+| `imagen-3.0-generate-002` | Imagen 3 — _retired; shutdown date was 2025-11-10, calls may already fail_ |
 
-The Imagen family is deprecated; migrate to the Gemini image models (Nano Banana). Run `tinct generate -i google-genai --ai.list-models` to print this list (works offline; no API key needed). Pricing is approximate — see the [Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing).
+The Imagen family is deprecated; Google recommends migrating to `gemini-3.1-flash-image`. Selecting one of these models prints a migration warning to stderr. The dates above are Google's [published shutdown dates](https://ai.google.dev/gemini-api/docs/deprecations), which are the *earliest possible* retirement dates rather than firm ones — a model may keep working past them. Run `tinct generate -i google-genai --ai.list-models` to print this list (works offline; no API key needed). Pricing is approximate — see the [Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing).
 
 ## Flags
 

--- a/internal/plugin/input/googlegenai/README.md
+++ b/internal/plugin/input/googlegenai/README.md
@@ -69,12 +69,12 @@ Generated images are cached under `~/.cache/tinct/generated/google-genai/`. Each
 | `gemini-3-pro-image-preview` | Nano Banana Pro — highest quality (~$0.134/image) |
 | `gemini-3.1-flash-image` | **Default.** Nano Banana 2, GA — fast, balanced quality (~$0.0672/image) |
 | `gemini-2.5-flash-image` | Nano Banana — cheapest Gemini image model (~$0.039/image) |
-| `imagen-4.0-ultra-generate-001` | Imagen 4 Ultra — _deprecated, shuts down 2026-08-17_ |
-| `imagen-4.0-generate-001` | Imagen 4 — _deprecated, shuts down 2026-08-17_ |
-| `imagen-4.0-fast-generate-001` | Imagen 4 Fast — _deprecated, shuts down 2026-08-17_ |
-| `imagen-3.0-generate-002` | Imagen 3 — _deprecated, shuts down 2026-08-17_ |
+| `imagen-4.0-ultra-generate-001` | Imagen 4 Ultra — _deprecated, earliest shutdown 2026-08-17_ |
+| `imagen-4.0-generate-001` | Imagen 4 — _deprecated, earliest shutdown 2026-08-17_ |
+| `imagen-4.0-fast-generate-001` | Imagen 4 Fast — _deprecated, earliest shutdown 2026-08-17_ |
+| `imagen-3.0-generate-002` | Imagen 3 — _retired; shutdown date was 2025-11-10, calls may already fail_ |
 
-The Imagen family is deprecated; migrate to the Gemini image models (Nano Banana). Run `tinct generate -i google-genai --ai.list-models` to print this list (works offline; no API key needed). Pricing is approximate — see the [Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing).
+The Imagen family is deprecated; Google recommends migrating to `gemini-3.1-flash-image`. Selecting one of these models prints a migration warning to stderr. The dates above are Google's [published shutdown dates](https://ai.google.dev/gemini-api/docs/deprecations), which are the *earliest possible* retirement dates rather than firm ones — a model may keep working past them. Run `tinct generate -i google-genai --ai.list-models` to print this list (works offline; no API key needed). Pricing is approximate — see the [Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing).
 
 ## Flags
 

--- a/internal/plugin/input/googlegenai/googlegenai.go
+++ b/internal/plugin/input/googlegenai/googlegenai.go
@@ -36,6 +36,33 @@ const (
 	defaultBackend = "gemini-api"
 )
 
+// deprecatedModels maps a retired or soon-to-be-retired model ID to the
+// advice printed when someone selects it explicitly. The same information
+// is in the ListModels catalogue, but that is only seen by users who run
+// --ai.list-models; a model pinned in a script or tinct.toml would
+// otherwise fail with nothing but the raw API error.
+//
+// Dates are Google's published shutdown dates. Per
+// https://ai.google.dev/gemini-api/docs/deprecations these are the
+// earliest possible retirement dates rather than firm ones, except where
+// the date has already passed.
+var deprecatedModels = map[string]string{
+	"imagen-4.0-ultra-generate-001": "deprecated; earliest shutdown 2026-08-17. Google recommends gemini-3.1-flash-image (gemini-3-pro-image-preview is the nearest quality tier)",
+	"imagen-4.0-generate-001":       "deprecated; earliest shutdown 2026-08-17. Migrate to gemini-3.1-flash-image",
+	"imagen-4.0-fast-generate-001":  "deprecated; earliest shutdown 2026-08-17. Migrate to gemini-3.1-flash-image",
+	"imagen-3.0-generate-002":       "retired; its shutdown date was 2025-11-10, so calls may already fail. Migrate to gemini-3.1-flash-image",
+}
+
+// warnIfDeprecatedModel prints migration advice to stderr when the chosen
+// model is on the deprecation list. It never blocks the run: the dates are
+// Google's earliest possible retirement dates, so a model may well keep
+// working past them.
+func warnIfDeprecatedModel(model string) {
+	if advice, ok := deprecatedModels[model]; ok {
+		fmt.Fprintf(os.Stderr, "Warning: model %q is %s\n", model, advice)
+	}
+}
+
 // ImageMetadata contains metadata about a generated image.
 type ImageMetadata struct {
 	// Generation parameters
@@ -134,6 +161,10 @@ func (p *Plugin) Generate(ctx context.Context, opts input.GenerateOptions) (*col
 	if model == "" || model == "auto" {
 		model = defaultModel
 	}
+
+	// Warn as soon as the model is known, so the advice is visible on
+	// dry runs and on failures that happen before generation starts.
+	warnIfDeprecatedModel(model)
 
 	if opts.Verbose {
 		fmt.Fprintf(os.Stderr, "Google Gen AI Plugin Configuration:\n")
@@ -657,7 +688,7 @@ func ListModels() {
 			Description: "Highest quality, best prompt alignment",
 			Cost:        "$0.06",
 			Generation:  "4",
-			Notes:       "Deprecated — shuts down 2026-08-17; migrate to gemini-3-pro-image-preview",
+			Notes:       "Deprecated — earliest shutdown 2026-08-17. Google recommends gemini-3.1-flash-image; gemini-3-pro-image-preview is the nearest quality tier",
 		},
 		{
 			ID:          "imagen-4.0-generate-001",
@@ -665,7 +696,7 @@ func ListModels() {
 			Description: "Flagship model with balanced quality and speed",
 			Cost:        "$0.04",
 			Generation:  "4",
-			Notes:       "Deprecated — shuts down 2026-08-17; migrate to gemini-2.5-flash-image",
+			Notes:       "Deprecated — earliest shutdown 2026-08-17; migrate to gemini-3.1-flash-image",
 		},
 		{
 			ID:          "imagen-4.0-fast-generate-001",
@@ -673,7 +704,7 @@ func ListModels() {
 			Description: "Fastest generation, ideal for high-volume tasks",
 			Cost:        "$0.02",
 			Generation:  "4",
-			Notes:       "Deprecated — shuts down 2026-08-17; migrate to gemini-2.5-flash-image",
+			Notes:       "Deprecated — earliest shutdown 2026-08-17; migrate to gemini-3.1-flash-image",
 		},
 		{
 			ID:          "imagen-3.0-generate-002",
@@ -681,7 +712,7 @@ func ListModels() {
 			Description: "Previous generation model (stable)",
 			Cost:        "$0.03",
 			Generation:  "3",
-			Notes:       "Deprecated — shuts down 2026-08-17; migrate to gemini-2.5-flash-image",
+			Notes:       "Retired — shutdown date was 2025-11-10; expect API errors. Migrate to gemini-3.1-flash-image",
 		},
 	}
 

--- a/internal/plugin/input/googlegenai/googlegenai_test.go
+++ b/internal/plugin/input/googlegenai/googlegenai_test.go
@@ -2,6 +2,7 @@ package googlegenai
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -496,5 +497,210 @@ func TestWarnIfDeprecatedModelIsSilentForLiveModels(t *testing.T) {
 		if _, ok := deprecatedModels[id]; ok {
 			t.Errorf("live model %q must not be on the deprecation list", id)
 		}
+	}
+}
+
+// captureStderr runs fn with os.Stderr redirected and returns what it wrote.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// TestWarnIfDeprecatedModelOutput checks the warning users actually see: that
+// it names the model, explains the status, and points at a live replacement.
+func TestWarnIfDeprecatedModelOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		wantWarning bool
+		wantSubstr  []string
+	}{
+		{
+			name:        "retired 3.0 reports its real past shutdown date",
+			model:       "imagen-3.0-generate-002",
+			wantWarning: true,
+			// The date this PR corrects: it was previously advertised as 2026-08-17.
+			wantSubstr: []string{"imagen-3.0-generate-002", "retired", "2025-11-10", "gemini-3.1-flash-image"},
+		},
+		{
+			name:        "deprecated 4.0 reports earliest-shutdown wording",
+			model:       "imagen-4.0-generate-001",
+			wantWarning: true,
+			wantSubstr:  []string{"imagen-4.0-generate-001", "earliest shutdown", "2026-08-17", "gemini-3.1-flash-image"},
+		},
+		{
+			name:        "ultra names the nearest quality tier as well",
+			model:       "imagen-4.0-ultra-generate-001",
+			wantWarning: true,
+			wantSubstr:  []string{"gemini-3.1-flash-image", "gemini-3-pro-image-preview"},
+		},
+		{
+			name:        "default model is silent",
+			model:       defaultModel,
+			wantWarning: false,
+		},
+		{
+			name:        "unknown model is silent",
+			model:       "some-future-model",
+			wantWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStderr(t, func() { warnIfDeprecatedModel(tt.model) })
+
+			if !tt.wantWarning {
+				if out != "" {
+					t.Errorf("expected no warning for %q, got %q", tt.model, out)
+				}
+				return
+			}
+
+			if out == "" {
+				t.Fatalf("expected a warning for %q, got none", tt.model)
+			}
+			for _, want := range tt.wantSubstr {
+				if !strings.Contains(out, want) {
+					t.Errorf("warning for %q missing %q\ngot: %s", tt.model, want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestWarnIfDeprecatedModelNeverMentionsARetiredReplacement guards the failure
+// mode where advice sends a user from one dead model to another: Google's own
+// table lists imagen-4.0-generate-001 as the replacement for imagen-3.0, and
+// that model is itself on the way out.
+func TestWarnIfDeprecatedModelNeverMentionsARetiredReplacement(t *testing.T) {
+	for model := range deprecatedModels {
+		out := captureStderr(t, func() { warnIfDeprecatedModel(model) })
+		for dead := range deprecatedModels {
+			if dead == model {
+				continue
+			}
+			if strings.Contains(out, dead) {
+				t.Errorf("advice for %q points at deprecated model %q: %s", model, dead, out)
+			}
+		}
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it wrote.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+// TestListModelsOutput covers the catalogue rendering, which is the only place
+// a user can discover model status. It runs offline and needs no API key.
+func TestListModelsOutput(t *testing.T) {
+	out := captureStdout(t, ListModels)
+
+	if out == "" {
+		t.Fatal("ListModels produced no output")
+	}
+
+	// Every model the plugin accepts must be listed, or users cannot discover it.
+	for _, id := range []string{
+		"gemini-3-pro-image-preview",
+		"gemini-3.1-flash-image",
+		"gemini-2.5-flash-image",
+		"imagen-4.0-ultra-generate-001",
+		"imagen-4.0-generate-001",
+		"imagen-4.0-fast-generate-001",
+		"imagen-3.0-generate-002",
+	} {
+		if !strings.Contains(out, id) {
+			t.Errorf("model %q missing from ListModels output", id)
+		}
+	}
+
+	// The default must be identified as such.
+	if !strings.Contains(out, defaultModel) {
+		t.Errorf("default model %q not named in output", defaultModel)
+	}
+	if !strings.Contains(out, "Default Model:") {
+		t.Error("output does not label the default model")
+	}
+
+	// Every deprecated model must carry a visible note. Without this the
+	// catalogue can silently list a dead model as though it were live.
+	for id := range deprecatedModels {
+		idx := strings.Index(out, id)
+		if idx < 0 {
+			continue // reported above
+		}
+		rest := out[idx:]
+		if end := strings.Index(rest, "ID: "); end > 0 {
+			rest = rest[:end]
+		}
+		if !strings.Contains(rest, "Notes:") {
+			t.Errorf("deprecated model %q has no Notes line in ListModels output", id)
+		}
+	}
+}
+
+// TestListModelsReportsCorrectedShutdownDates pins the specific dates this
+// change fixes, so a future edit cannot quietly reintroduce the wrong one.
+func TestListModelsReportsCorrectedShutdownDates(t *testing.T) {
+	out := captureStdout(t, ListModels)
+
+	// imagen-3.0 was previously advertised with the 4.0 family's date.
+	idx := strings.Index(out, "imagen-3.0-generate-002")
+	if idx < 0 {
+		t.Fatal("imagen-3.0-generate-002 missing from output")
+	}
+	entry := out[idx:]
+	if end := strings.Index(entry, "ID: "); end > 0 {
+		entry = entry[:end]
+	}
+	if strings.Contains(entry, "2026-08-17") {
+		t.Errorf("imagen-3.0-generate-002 still shows the 4.0 shutdown date:\n%s", entry)
+	}
+	if !strings.Contains(entry, "2025-11-10") {
+		t.Errorf("imagen-3.0-generate-002 missing its real shutdown date:\n%s", entry)
+	}
+
+	// Google's dates are earliest-possible; the wording must not overstate them.
+	if strings.Contains(out, "shuts down 2026-08-17") {
+		t.Error("output states a firm shutdown date; Google publishes earliest-possible dates")
 	}
 }

--- a/internal/plugin/input/googlegenai/googlegenai_test.go
+++ b/internal/plugin/input/googlegenai/googlegenai_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/jmylchreest/tinct/internal/plugin/input"
@@ -448,5 +449,52 @@ func TestGetImageBasePathStripsExtension(t *testing.T) {
 	}
 	if filepath.Base(base) != "mywallpaper" {
 		t.Errorf("expected base name 'mywallpaper', got %q", filepath.Base(base))
+	}
+}
+
+// TestDeprecatedModelsMatchCatalogue guards against the two lists drifting:
+// every model carrying a Notes entry in the ListModels catalogue must also
+// appear in deprecatedModels, so a user who pins that model on the command
+// line gets the same warning that --ai.list-models shows.
+func TestDeprecatedModelsMatchCatalogue(t *testing.T) {
+	// The catalogue is built inside ListModels, so assert against the model
+	// IDs we know carry deprecation notes.
+	wantDeprecated := []string{
+		"imagen-4.0-ultra-generate-001",
+		"imagen-4.0-generate-001",
+		"imagen-4.0-fast-generate-001",
+		"imagen-3.0-generate-002",
+	}
+
+	for _, id := range wantDeprecated {
+		if _, ok := deprecatedModels[id]; !ok {
+			t.Errorf("model %q is deprecated in the catalogue but missing from deprecatedModels", id)
+		}
+	}
+
+	if len(deprecatedModels) != len(wantDeprecated) {
+		t.Errorf("deprecatedModels has %d entries, want %d", len(deprecatedModels), len(wantDeprecated))
+	}
+
+	// The default must never itself be deprecated.
+	if _, ok := deprecatedModels[defaultModel]; ok {
+		t.Errorf("defaultModel %q is on the deprecation list", defaultModel)
+	}
+
+	// Every replacement suggestion must name a live Gemini model.
+	for id, advice := range deprecatedModels {
+		if !strings.Contains(advice, "gemini-") {
+			t.Errorf("advice for %q does not name a replacement model: %q", id, advice)
+		}
+	}
+}
+
+// TestWarnIfDeprecatedModelIsSilentForLiveModels ensures the warning does not
+// fire for the models we actually recommend.
+func TestWarnIfDeprecatedModelIsSilentForLiveModels(t *testing.T) {
+	for _, id := range []string{defaultModel, "gemini-3-pro-image-preview", "gemini-2.5-flash-image"} {
+		if _, ok := deprecatedModels[id]; ok {
+			t.Errorf("live model %q must not be on the deprecation list", id)
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #9. While checking whether the genai Imagen deprecation needed a
migration path, the answer turned out to be "the path already exists" — but the
dates describing it were wrong.

## What was wrong

The catalogue gave all four Imagen models a shutdown date of `2026-08-17`.
Checked against [Google's deprecation page](https://ai.google.dev/gemini-api/docs/deprecations),
that is correct for the three 4.0 models but wrong for `imagen-3.0-generate-002`,
whose published shutdown was **2025-11-10** — nine months ago. Verbatim from
their table:

```
imagen-3.0-generate-002 | February 6, 2025 | November 10, 2025 | imagen-4.0-generate-001
```

So we were advertising a model as live, with a future date, that had most likely
already stopped working.

That page also states its dates are the **earliest possible** retirement dates,
not firm ones, so "shuts down" overstated them. Wording is now "earliest
shutdown". Replacement advice points at `gemini-3.1-flash-image`, which is what
Google recommends for the 4.0 models — the previous notes pointed two of them at
`gemini-2.5-flash-image`. Ultra additionally names `gemini-3-pro-image-preview`
as the nearest quality tier.

## The warning nobody saw

The deprecation notes only ever rendered inside `--ai.list-models`. Anyone with a
model pinned in a script or `tinct.toml` saw nothing, and would have got a raw
API error once it went away.

`warnIfDeprecatedModel` now prints to stderr as soon as the model is resolved.
Placing it there rather than at the API call means it also covers `--dry-run` and
`extract`, both verified:

```
$ tinct generate -i google-genai --ai.model imagen-3.0-generate-002 --ai.prompt t --dry-run -o kitty
Warning: model "imagen-3.0-generate-002" is retired; its shutdown date was 2025-11-10,
so calls may already fail. Migrate to gemini-3.1-flash-image
```

It does not block the run — these are earliest-possible dates, and a model may
well keep working past them.

## Defaults

No change needed: `defaultModel` is already `gemini-3.1-flash-image`, which is
what `--ai.model auto` resolves to, and three of the seven catalogue entries are
Gemini. A test now asserts the default can never itself appear on the deprecation
list.

## Tests

Two guards, both mutation-checked — removing a map entry makes
`TestDeprecatedModelsMatchCatalogue` fail with the specific model named, so they
are not passing vacuously:

- the deprecation map and the catalogue cannot drift apart
- every entry's advice must name a live `gemini-` replacement
- the default and the other live models must never be on the list

`go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues) and the full test suite
all pass; `tinct-check-readmes` reports 0 warnings and the docs sync is clean.