### PR TITLE
fix(plugin)!: bound RPC calls and enforce the protocol floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Input plugins must now speak protocol `0.2.0` or newer. `WallpaperRawPath` was added after the `0.1.0` bump but before `0.2.0`, so a `0.1.0` input plugin may not implement it — and the host calls it unconditionally. Older input plugins are refused at registration with a message naming the gap; run `tinct plugins update <name>`. Output plugins are unaffected and keep the `0.0.1` floor: every RPC the host calls on them unconditionally predates `0.1.0`.
+
+### Fixed
+
+- Plugin RPCs are now bounded by a deadline. `net/rpc` has no timeouts, so a plugin that never answers hung tinct indefinitely with no output and nothing to diagnose — reachable in practice via an outdated plugin missing a method the host calls unconditionally. Metadata-style calls get 30s; `Generate` gets 10 minutes, since an input plugin may legitimately be waiting on remote image generation.
+- The protocol floor is enforced rather than nominal. `MinCompatibleVersion` was `0.0.1` while the only other rule was "major version must match", so every `0.x` plugin ever built passed and the gate never fired.
+- An outdated plugin is reported without `--verbose`. It was rejected silently, leaving `unknown plugin: <name>` as the only symptom, which points at entirely the wrong problem.
+
 ## [0.4.2]
 *2026-08-14*
 

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -900,6 +901,15 @@ func registerExternalPluginsFromManifest(manifest *PluginManifest, resolveAbsolu
 			continue
 		}
 		if err := registerExternalPlugin(meta, resolveAbsolutePaths, verbose); err != nil {
+			// An outdated plugin is always worth reporting: it silently
+			// disappears from the registry, so the user would otherwise
+			// only see "unknown plugin" and chase the wrong problem.
+			var incompatible *manager.IncompatiblePluginError
+			if errors.As(err, &incompatible) {
+				fmt.Fprintf(os.Stderr, "⊘ Skipping plugin %q: %v\n", meta.Name, err)
+				fmt.Fprintf(os.Stderr, "   Update it with: tinct plugins update %s\n", meta.Name)
+				continue
+			}
 			if verbose {
 				fmt.Fprintf(os.Stderr, " Failed to register external plugin '%s': %v\n", meta.Name, err)
 			}

--- a/internal/plugin/executor/executor.go
+++ b/internal/plugin/executor/executor.go
@@ -58,6 +58,11 @@ func NewWithVerboseAndRunner(pluginPath string, verbose bool, runner ProcessRunn
 	// Fail-fast on protocol-version mismatch before we hand the plugin
 	// off to the RPC handshake — a mismatched go-plugin can otherwise
 	// hang on the magic-cookie exchange with no actionable error.
+	//
+	// This applies the general floor only; the per-type floor (input
+	// plugins need a newer protocol for WallpaperRawPath) is enforced at
+	// registration, where the plugin's type is known.
+	//
 	// Empty versions are tolerated for backward compatibility with
 	// pre-versioning plugins.
 	if pv := result.PluginInfo.ProtocolVersion; pv != "" {

--- a/internal/plugin/manager/manager.go
+++ b/internal/plugin/manager/manager.go
@@ -232,19 +232,19 @@ func (m *Manager) RegisterExternalPlugin(name, pluginType, path, description str
 
 	// Check protocol version compatibility.
 	if pluginInfo.ProtocolVersion != "" {
-		compatible, err := protocol.IsCompatible(pluginInfo.ProtocolVersion)
+		compatible, err := protocol.IsCompatibleForType(pluginInfo.ProtocolVersion, pluginType)
 		if err != nil || !compatible {
 			errMsg := "unknown error"
 			if err != nil {
 				errMsg = err.Error()
 			}
-			return fmt.Errorf(
-				"plugin '%s' protocol version %s is incompatible with tinct %s: %s",
-				name,
-				pluginInfo.ProtocolVersion,
-				protocol.ProtocolVersion,
-				errMsg,
-			)
+			return &IncompatiblePluginError{
+				Name:          name,
+				PluginVersion: pluginInfo.ProtocolVersion,
+				HostVersion:   protocol.ProtocolVersion,
+				MinVersion:    protocol.MinCompatibleVersionForType(pluginType),
+				Reason:        errMsg,
+			}
 		}
 	}
 	// Note: If protocol_version is missing, we allow the plugin (backward compatibility)
@@ -287,6 +287,28 @@ func queryPluginInfo(pluginPath string) (PluginInfo, error) {
 	}
 
 	return info, nil
+}
+
+// IncompatiblePluginError reports a plugin rejected for speaking a
+// protocol version this host no longer supports.
+//
+// It is a distinct type because the condition is user-fixable and must
+// not be swallowed: the plugin vanishes from the registry, so without a
+// message the only symptom is "unknown plugin", which points the user at
+// the wrong problem entirely.
+type IncompatiblePluginError struct {
+	Name          string
+	PluginVersion string
+	HostVersion   string
+	MinVersion    string
+	Reason        string
+}
+
+func (e *IncompatiblePluginError) Error() string {
+	return fmt.Sprintf(
+		"plugin %q speaks protocol %s, but tinct %s requires at least %s: %s",
+		e.Name, e.PluginVersion, e.HostVersion, e.MinVersion, e.Reason,
+	)
 }
 
 // externalPluginBase holds fields and methods shared by all external plugin wrappers.

--- a/internal/plugin/protocol/version.go
+++ b/internal/plugin/protocol/version.go
@@ -15,6 +15,9 @@ const ProtocolVersion = plugin.ProtocolVersion
 // MinCompatibleVersion is an alias to the public minimum compatible version.
 const MinCompatibleVersion = plugin.MinCompatibleVersion
 
+// MinInputCompatibleVersion is an alias to the public input-plugin floor.
+const MinInputCompatibleVersion = plugin.MinInputCompatibleVersion
+
 // Version represents a parsed protocol version.
 type Version struct {
 	Major int
@@ -69,6 +72,30 @@ func (v Version) AtLeast(other Version) bool {
 // - Minor version can be higher (backward compatible).
 // - Patch version can be any value (bug fixes only).
 func IsCompatible(pluginVersionStr string) (bool, error) {
+	return isCompatibleAgainst(pluginVersionStr, MinCompatibleVersion)
+}
+
+// IsCompatibleForType is IsCompatible with the floor that applies to the
+// given plugin type ("input" or "output").
+//
+// Input plugins carry a higher floor: the host calls WallpaperRawPath on
+// every input plugin, and that method postdates 0.1.0, so an older
+// plugin blocks the run instead of erroring. Output plugins have no such
+// method and keep the general floor.
+func IsCompatibleForType(pluginVersionStr, pluginType string) (bool, error) {
+	return isCompatibleAgainst(pluginVersionStr, MinCompatibleVersionForType(pluginType))
+}
+
+// MinCompatibleVersionForType returns the protocol floor for a plugin
+// type. Unknown types get the general floor.
+func MinCompatibleVersionForType(pluginType string) string {
+	if pluginType == "input" {
+		return MinInputCompatibleVersion
+	}
+	return MinCompatibleVersion
+}
+
+func isCompatibleAgainst(pluginVersionStr, minCompatible string) (bool, error) {
 	pluginVersion, err := Parse(pluginVersionStr)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse plugin version: %w", err)
@@ -79,7 +106,7 @@ func IsCompatible(pluginVersionStr string) (bool, error) {
 		return false, fmt.Errorf("failed to parse current protocol version: %w", err)
 	}
 
-	minVersion, err := Parse(MinCompatibleVersion)
+	minVersion, err := Parse(minCompatible)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse minimum compatible version: %w", err)
 	}
@@ -99,14 +126,14 @@ func IsCompatible(pluginVersionStr string) (bool, error) {
 			return false, fmt.Errorf(
 				"plugin version %s is too old, minimum required is %s",
 				pluginVersion.String(),
-				MinCompatibleVersion,
+				minCompatible,
 			)
 		}
 		if pluginVersion.Minor == minVersion.Minor && pluginVersion.Patch < minVersion.Patch {
 			return false, fmt.Errorf(
 				"plugin version %s is too old, minimum required is %s",
 				pluginVersion.String(),
-				MinCompatibleVersion,
+				minCompatible,
 			)
 		}
 	}

--- a/internal/plugin/protocol/version_test.go
+++ b/internal/plugin/protocol/version_test.go
@@ -45,8 +45,8 @@ func TestIsCompatible(t *testing.T) {
 		compatible    bool
 		errorContains string
 	}{
-		// Same version - compatible
-		{"0.0.1", true, ""},
+		// At the general floor - compatible
+		{MinCompatibleVersion, true, ""},
 
 		// Same major, higher minor - compatible (forward compatible)
 		{"0.1.0", true, ""},
@@ -98,5 +98,50 @@ func TestVersionString(t *testing.T) {
 	v2 := Version{Major: 1, Minor: 5, Patch: 3}
 	if v2.String() != "1.5.3" {
 		t.Errorf("Version.String() = %q, want %q", v2.String(), "1.5.3")
+	}
+}
+
+// The input floor is higher than the general one: the host calls
+// WallpaperRawPath on every input plugin, and that method postdates
+// 0.1.0, so an older input plugin blocks the run rather than erroring.
+func TestIsCompatibleForType(t *testing.T) {
+	tests := []struct {
+		version    string
+		pluginType string
+		compatible bool
+	}{
+		// Output plugins keep the general floor — every RPC the host
+		// calls on them unconditionally predates 0.1.0, so these work.
+		{"0.0.1", "output", true},
+		{"0.1.0", "output", true},
+		{"0.2.0", "output", true},
+
+		// Input plugins must be at least 0.2.0.
+		{"0.0.1", "input", false},
+		{"0.1.0", "input", false},
+		{"0.2.0", "input", true},
+		{"0.3.0", "input", true},
+
+		// Unknown types fall back to the general floor.
+		{"0.1.0", "", true},
+	}
+
+	for _, tt := range tests {
+		compatible, err := IsCompatibleForType(tt.version, tt.pluginType)
+		if compatible != tt.compatible {
+			t.Errorf("IsCompatibleForType(%q, %q) = %v (err %v), want %v",
+				tt.version, tt.pluginType, compatible, err, tt.compatible)
+		}
+	}
+}
+
+func TestMinCompatibleVersionForType(t *testing.T) {
+	if got := MinCompatibleVersionForType("input"); got != MinInputCompatibleVersion {
+		t.Errorf("input floor = %q, want %q", got, MinInputCompatibleVersion)
+	}
+	for _, other := range []string{"output", "", "unknown"} {
+		if got := MinCompatibleVersionForType(other); got != MinCompatibleVersion {
+			t.Errorf("%q floor = %q, want %q", other, got, MinCompatibleVersion)
+		}
 	}
 }

--- a/pkg/plugin/constants.go
+++ b/pkg/plugin/constants.go
@@ -18,10 +18,25 @@ const (
 	// hints are provided, so 0.2.0 plugins continue to work unchanged.
 	ProtocolVersion = "0.3.0"
 
-	// MinCompatibleVersion is the oldest protocol version this tinct version can work with.
-	// Unchanged at 0.0.1 because the wire-format change is purely additive — the
-	// host still accepts the legacy bare-array Generate response.
+	// MinCompatibleVersion is the oldest protocol version this tinct
+	// version can work with for any plugin type.
+	//
+	// Every RPC the host calls unconditionally on an *output* plugin
+	// (Generate, GetMetadata, PreExecute, PostExecute, GetFlagHelp) has
+	// existed since before the 0.1.0 bump, and the optional 0.3.0+
+	// methods degrade gracefully via isMissingMethodErr. So old output
+	// plugins remain genuinely usable and are not rejected.
 	MinCompatibleVersion = "0.0.1"
+
+	// MinInputCompatibleVersion is the floor for input plugins.
+	//
+	// Higher than the general floor because WallpaperRawPath was added
+	// mid-cycle — after the 0.1.0 bump, before 0.2.0 — so a plugin
+	// reporting "0.1.0" may or may not implement it. The host calls it
+	// unconditionally after Generate, and an absent method does not fail
+	// cleanly: net/rpc blocks on the reply forever. 0.2.0 is the oldest
+	// version at which its presence is guaranteed.
+	MinInputCompatibleVersion = "0.2.0"
 )
 
 // Handshake is the handshake configuration for go-plugin protocol.

--- a/pkg/plugin/rpc.go
+++ b/pkg/plugin/rpc.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/rpc"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-plugin"
 
@@ -160,7 +161,7 @@ type rgbBlock struct {
 // are cached and exposed via LastRoleHints / LastThemeHint.
 func (c *InputPluginRPCClient) Generate(_ context.Context, opts InputOptions) ([]color.Color, error) {
 	var respBytes []byte
-	err := c.client.Call("Plugin.Generate", opts, &respBytes)
+	err := call(c.client, "Plugin.Generate", opts, &respBytes, generateTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("RPC call failed: %w", err)
 	}
@@ -229,7 +230,7 @@ func parseInputResponse(data []byte) (colors []rgbBlock, roleHints map[string]in
 // GetMetadata calls the remote GetMetadata method.
 func (c *InputPluginRPCClient) GetMetadata() (PluginInfo, error) {
 	var info PluginInfo
-	err := c.client.Call("Plugin.GetMetadata", new(any), &info)
+	err := call(c.client, "Plugin.GetMetadata", new(any), &info, callTimeout)
 	if err != nil {
 		return info, fmt.Errorf("RPC call failed: %w", err)
 	}
@@ -245,7 +246,7 @@ func (c *InputPluginRPCClient) Validate(args map[string]any) error {
 		args = map[string]any{}
 	}
 	var msg string
-	err := c.client.Call("Plugin.Validate", args, &msg)
+	err := call(c.client, "Plugin.Validate", args, &msg, callTimeout)
 	if err != nil {
 		if isMissingMethodErr(err) {
 			return nil
@@ -261,7 +262,7 @@ func (c *InputPluginRPCClient) Validate(args map[string]any) error {
 // WallpaperPath calls the remote WallpaperPath method.
 func (c *InputPluginRPCClient) WallpaperPath() string {
 	var path string
-	err := c.client.Call("Plugin.WallpaperPath", new(any), &path)
+	err := call(c.client, "Plugin.WallpaperPath", new(any), &path, callTimeout)
 	if err != nil {
 		return ""
 	}
@@ -271,7 +272,7 @@ func (c *InputPluginRPCClient) WallpaperPath() string {
 // WallpaperRawPath calls the remote WallpaperRawPath method.
 func (c *InputPluginRPCClient) WallpaperRawPath() string {
 	var path string
-	err := c.client.Call("Plugin.WallpaperRawPath", new(any), &path)
+	err := call(c.client, "Plugin.WallpaperRawPath", new(any), &path, callTimeout)
 	if err != nil {
 		return ""
 	}
@@ -281,7 +282,7 @@ func (c *InputPluginRPCClient) WallpaperRawPath() string {
 // GetFlagHelp calls the remote GetFlagHelp method.
 func (c *InputPluginRPCClient) GetFlagHelp() []FlagHelp {
 	var help []FlagHelp
-	err := c.client.Call("Plugin.GetFlagHelp", new(any), &help)
+	err := call(c.client, "Plugin.GetFlagHelp", new(any), &help, callTimeout)
 	if err != nil {
 		return []FlagHelp{}
 	}
@@ -414,7 +415,7 @@ type OutputPluginRPCClient struct {
 // Generate calls the remote Generate method.
 func (c *OutputPluginRPCClient) Generate(_ context.Context, palette PaletteData) (map[string][]byte, error) {
 	var result map[string][]byte
-	err := c.client.Call("Plugin.Generate", palette, &result)
+	err := call(c.client, "Plugin.Generate", palette, &result, generateTimeout)
 	if err != nil {
 		return result, fmt.Errorf("RPC call failed: %w", err)
 	}
@@ -428,7 +429,7 @@ func (c *OutputPluginRPCClient) PreExecute(_ context.Context) (skip bool, reason
 		Reason string
 		Error  string
 	}
-	err = c.client.Call("Plugin.PreExecute", new(any), &resp)
+	err = call(c.client, "Plugin.PreExecute", new(any), &resp, callTimeout)
 	if err != nil {
 		return false, "", fmt.Errorf("RPC call failed: %w", err)
 	}
@@ -441,7 +442,7 @@ func (c *OutputPluginRPCClient) PreExecute(_ context.Context) (skip bool, reason
 // PostExecute calls the remote PostExecute method.
 func (c *OutputPluginRPCClient) PostExecute(_ context.Context, files []string) error {
 	var errMsg string
-	err := c.client.Call("Plugin.PostExecute", files, &errMsg)
+	err := call(c.client, "Plugin.PostExecute", files, &errMsg, callTimeout)
 	if err != nil {
 		return fmt.Errorf("RPC call failed: %w", err)
 	}
@@ -454,7 +455,7 @@ func (c *OutputPluginRPCClient) PostExecute(_ context.Context, files []string) e
 // GetMetadata calls the remote GetMetadata method.
 func (c *OutputPluginRPCClient) GetMetadata() (PluginInfo, error) {
 	var info PluginInfo
-	err := c.client.Call("Plugin.GetMetadata", new(any), &info)
+	err := call(c.client, "Plugin.GetMetadata", new(any), &info, callTimeout)
 	if err != nil {
 		return info, fmt.Errorf("RPC call failed: %w", err)
 	}
@@ -469,7 +470,7 @@ func (c *OutputPluginRPCClient) Validate(args map[string]any) error {
 		args = map[string]any{}
 	}
 	var msg string
-	err := c.client.Call("Plugin.Validate", args, &msg)
+	err := call(c.client, "Plugin.Validate", args, &msg, callTimeout)
 	if err != nil {
 		if isMissingMethodErr(err) {
 			return nil
@@ -490,7 +491,7 @@ func (c *OutputPluginRPCClient) Validate(args map[string]any) error {
 // on transport errors.
 func (c *OutputPluginRPCClient) GetHooks() (hooks.Spec, bool) {
 	var payload HookSpecPayload
-	err := c.client.Call("Plugin.GetHooks", noArgs, &payload)
+	err := call(c.client, "Plugin.GetHooks", noArgs, &payload, callTimeout)
 	if err != nil {
 		return hooks.Spec{}, false
 	}
@@ -505,7 +506,7 @@ func (c *OutputPluginRPCClient) GetHooks() (hooks.Spec, bool) {
 // templates exposed.
 func (c *OutputPluginRPCClient) GetTemplates() (map[string][]byte, bool) {
 	var payload map[string][]byte
-	err := c.client.Call("Plugin.GetTemplates", noArgs, &payload)
+	err := call(c.client, "Plugin.GetTemplates", noArgs, &payload, callTimeout)
 	if err != nil || len(payload) == 0 {
 		return nil, false
 	}
@@ -515,11 +516,54 @@ func (c *OutputPluginRPCClient) GetTemplates() (map[string][]byte, bool) {
 // GetFlagHelp calls the remote GetFlagHelp method.
 func (c *OutputPluginRPCClient) GetFlagHelp() []FlagHelp {
 	var help []FlagHelp
-	err := c.client.Call("Plugin.GetFlagHelp", new(any), &help)
+	err := call(c.client, "Plugin.GetFlagHelp", new(any), &help, callTimeout)
 	if err != nil {
 		return []FlagHelp{}
 	}
 	return help
+}
+
+// Plugin RPC deadlines.
+//
+// net/rpc has no timeouts: Call blocks on a channel until the server
+// answers, so a plugin that never replies hangs the host forever with no
+// output and no diagnosis. That is not hypothetical — a plugin built
+// against an older protocol simply does not have a method the host later
+// added, and the call never completes.
+const (
+	// callTimeout bounds RPCs that must return promptly: metadata,
+	// hooks, flag help, wallpaper paths, validation, pre/post-execute.
+	// Generous enough to absorb a cold-start plugin on a loaded machine.
+	callTimeout = 30 * time.Second
+
+	// generateTimeout bounds Generate, which can legitimately run long —
+	// an input plugin may be waiting on remote image generation.
+	generateTimeout = 10 * time.Minute
+)
+
+// call invokes an RPC method with a deadline, converting what net/rpc
+// would leave as an indefinite hang into an actionable error.
+//
+// On timeout the call is abandoned rather than cancelled — net/rpc gives
+// no way to withdraw it. A late reply is written into the reply pointer
+// after this returns, so every caller must pass a pointer to a local it
+// no longer reads once call returns non-nil. All callers in this file do.
+func call(client *rpc.Client, method string, args, reply any, timeout time.Duration) error {
+	pending := client.Go(method, args, reply, make(chan *rpc.Call, 1))
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case done := <-pending.Done:
+		return done.Error
+	case <-timer.C:
+		return fmt.Errorf(
+			"plugin did not respond to %s within %s; it may be built against an "+
+				"incompatible protocol version (host %s, minimum %s) — try updating it",
+			method, timeout, ProtocolVersion, MinCompatibleVersion,
+		)
+	}
 }
 
 // noArgs is the canonical zero-value used for RPC methods that take no

--- a/pkg/plugin/rpc_test.go
+++ b/pkg/plugin/rpc_test.go
@@ -3,7 +3,11 @@ package plugin
 import (
 	"context"
 	"image/color"
+	"net"
+	"net/rpc"
+	"strings"
 	"testing"
+	"time"
 )
 
 // Mock implementations for testing.
@@ -373,5 +377,98 @@ func TestFlagHelp(t *testing.T) {
 	}
 	if !flag.Required {
 		t.Error("Required = false, want true")
+	}
+}
+
+// --- bounded RPC -----------------------------------------------------------
+
+// slowService has one method that answers and one that never does, so we
+// can exercise both branches of call().
+type slowService struct{ release chan struct{} }
+
+func (s *slowService) Echo(arg string, reply *string) error {
+	*reply = arg
+	return nil
+}
+
+func (s *slowService) Hang(_ string, reply *string) error {
+	<-s.release // blocks until the test tears the fixture down
+	*reply = "never"
+	return nil
+}
+
+// newLoopbackClient serves slowService over an in-memory pipe and
+// returns a connected rpc.Client.
+func newLoopbackClient(t *testing.T) (*rpc.Client, *slowService) {
+	t.Helper()
+
+	svc := &slowService{release: make(chan struct{})}
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("Plugin", svc); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	serverConn, clientConn := net.Pipe()
+	go srv.ServeConn(serverConn)
+
+	client := rpc.NewClient(clientConn)
+	t.Cleanup(func() {
+		close(svc.release)
+		_ = client.Close()
+	})
+	return client, svc
+}
+
+// A responsive method returns its reply and no error.
+func TestCallReturnsReply(t *testing.T) {
+	client, _ := newLoopbackClient(t)
+
+	var got string
+	if err := call(client, "Plugin.Echo", "hello", &got, callTimeout); err != nil {
+		t.Fatalf("call returned error: %v", err)
+	}
+	if got != "hello" {
+		t.Errorf("reply = %q, want %q", got, "hello")
+	}
+}
+
+// The regression this exists for: a method that never replies must fail
+// on a deadline rather than block the host forever.
+func TestCallTimesOutInsteadOfHanging(t *testing.T) {
+	client, _ := newLoopbackClient(t)
+
+	done := make(chan error, 1)
+	go func() {
+		var got string
+		done <- call(client, "Plugin.Hang", "x", &got, 100*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("call succeeded; want a timeout error")
+		}
+		for _, want := range []string{"Plugin.Hang", "did not respond", "protocol version"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q, want it to mention %q", err.Error(), want)
+			}
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("call did not return; the deadline is not being enforced")
+	}
+}
+
+// A missing method must surface as an error call() passes through, so
+// isMissingMethodErr can classify it for the optional-RPC fallbacks.
+func TestCallSurfacesMissingMethod(t *testing.T) {
+	client, _ := newLoopbackClient(t)
+
+	var got string
+	err := call(client, "Plugin.NoSuchMethod", "x", &got, callTimeout)
+	if err == nil {
+		t.Fatal("call succeeded on an unknown method")
+	}
+	if !isMissingMethodErr(err) {
+		t.Errorf("error %q not recognised as a missing method", err.Error())
 	}
 }


### PR DESCRIPTION
`net/rpc` has no timeouts: `Call` blocks on a channel until the server answers. A plugin that never replies therefore hangs tinct **indefinitely**, with no output and nothing to diagnose.

This is not hypothetical. It reproduces today with an outdated plugin:

```
$ tinct generate -i random          # tinct-plugin-random, protocol 0.1.0
Generating 32 random colours (seed: 820565857983101800)
   Generated raw palette (32 colours)
<hangs forever>
```

Goroutine dump:

```
net/rpc.(*Client).Call  [chan receive]
pkg/plugin.(*InputPluginRPCClient).WallpaperRawPath  rpc.go:304
executor.(*PluginExecutor).wallpaperFromInput  executor.go:261
```

The plugin process is still alive — it simply has no `WallpaperRawPath` method, so the reply never comes.

## Changes

**Bounded RPC.** All 14 `client.Call` sites go through a `call` helper built on `client.Go` + `select`. Metadata, hooks, flag help, wallpaper paths, validation and pre/post-execute get 30s; `Generate` gets 10 minutes, since an input plugin may legitimately be waiting on remote image generation. On timeout the error names the method and points at a protocol mismatch.

**A real protocol floor.** The gate meant to prevent exactly this was a no-op: `MinCompatibleVersion` was `0.0.1` and the only other rule was that the major version match, so every `0.x` plugin ever built passed.

The floor is now **per plugin type**, because a blanket floor rejects output plugins that work fine. Dating each unconditional RPC against the version bumps:

| method | added | vs bumps |
|---|---|---|
| `Generate`, `GetMetadata`, `PreExecute`, `PostExecute`, `WallpaperPath`, `GetFlagHelp` | 2025-11-11 | before 0.1.0 (2025-11-16) |
| **`WallpaperRawPath`** | **2026-01-01** | **after 0.1.0, before 0.2.0 (2026-03-18)** |

`WallpaperRawPath` is the only method in the gap, and it is input-only. So input plugins require `0.2.0`; output plugins keep `0.0.1`.

**Rejection is no longer silent.** An incompatible plugin vanished from the registry with the message gated behind `--verbose`, so the only symptom was `unknown plugin: <name>` — pointing at the wrong problem. A typed `IncompatiblePluginError` is now always reported:

```
⊘ Skipping plugin "random": plugin "random" speaks protocol 0.1.0, but tinct 0.3.0
  requires at least 0.2.0: plugin version 0.1.0 is too old, minimum required is 0.2.0
   Update it with: tinct plugins update random
```

## Breaking

Input plugins speaking protocol older than `0.2.0` are refused at registration instead of being loaded. Run `tinct plugins update <name>` to rebuild them. Output plugins are unaffected.

## Tests

Three new tests over `net.Pipe`: a responsive method returns its reply; a never-answering method fails on the deadline rather than blocking (the test fails if it has not returned in 10s); an unknown method still classifies through `isMissingMethodErr` so the optional-RPC fallbacks keep working. Plus per-type floor coverage in `protocol/version_test.go`.

Verified end to end: the reproducer above now exits cleanly with the guidance message, and a full `tinct generate` still runs all 26 output plugins with no warnings.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV