### PR TITLE
fix(cli): honour the plugin name argument in `tinct plugins update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 ## [Unreleased]
 
+### Fixed
+
+- `tinct plugins update <name>` now updates only the named plugin. The command declared no positional arguments and never read them, so cobra accepted the name, discarded it, and updated every plugin in the manifest. An unknown name is now an error listing what is installed, rather than a silent full update.
+- `tinct plugins update` can update plugins added from a local path. Local sources record their origin in `source.original_path`, which the update path never consulted — so every plugin installed with `tinct plugins add ./binary` reported "No source information" and could never be updated.
+
 ### Breaking changes
 
 - Input plugins must now speak protocol `0.2.0` or newer. `WallpaperRawPath` was added after the `0.1.0` bump but before `0.2.0`, so a `0.1.0` input plugin may not implement it — and the host calls it unconditionally. Older input plugins are refused at registration with a message naming the gap; run `tinct plugins update <name>`. Output plugins are unaffected and keep the `0.0.1` floor: every RPC the host calls on them unconditionally predates `0.1.0`.

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -198,16 +198,21 @@ Examples:
 
 // pluginUpdateCmd updates external plugins from manifest sources.
 var pluginUpdateCmd = &cobra.Command{
-	Use:   "update",
+	Use:   "update [name...]",
 	Short: "Update external plugins from manifest sources",
 	Long: `Update external plugins by re-downloading/copying from their source locations.
 
-This reads the plugin manifest and updates all external plugins based on their
-source field. Useful for keeping plugins in sync across machines or after
-pulling manifest changes from a shared dotfiles repo.
+This reads the plugin manifest and updates plugins based on their source field.
+Useful for keeping plugins in sync across machines or after pulling manifest
+changes from a shared dotfiles repo.
+
+Named plugins are updated on their own; with no names, every external plugin in
+the manifest is updated.
 
 Examples:
   tinct plugins update
+  tinct plugins update noctalia
+  tinct plugins update noctalia zed
   tinct plugins update --manifest-file /path/to/plugins.manifest.json`,
 	RunE: runPluginUpdate,
 }
@@ -541,8 +546,54 @@ func updatePluginFromRepository(meta *ExternalPluginMeta, pluginDir string, verb
 	return pluginPath, nil
 }
 
+// selectPluginsToUpdate resolves the plugin names to update, sorted.
+//
+// With no names, every external plugin in the manifest is returned —
+// the historical behaviour. With names, only those are returned, and an
+// unknown one is an error rather than a silent no-op.
+//
+// This exists because the command previously declared no positional
+// arguments and never read them: cobra accepted `tinct plugins update
+// noctalia` and then updated everything, which is both surprising and
+// slow when a user wants one plugin refreshed.
+func selectPluginsToUpdate(lock *PluginManifest, names []string) ([]string, error) {
+	if len(names) == 0 {
+		all := make([]string, 0, len(lock.ExternalPlugins))
+		for name := range lock.ExternalPlugins {
+			all = append(all, name)
+		}
+		sort.Strings(all)
+		return all, nil
+	}
+
+	known := make([]string, 0, len(lock.ExternalPlugins))
+	for name := range lock.ExternalPlugins {
+		known = append(known, name)
+	}
+	sort.Strings(known)
+
+	seen := make(map[string]bool, len(names))
+	selected := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, ok := lock.ExternalPlugins[name]; !ok {
+			return nil, fmt.Errorf(
+				"unknown plugin %q (installed: %s)",
+				name, strings.Join(known, ", "),
+			)
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		selected = append(selected, name)
+	}
+
+	sort.Strings(selected)
+	return selected, nil
+}
+
 // runPluginUpdate updates external plugins from manifest sources.
-func runPluginUpdate(cmd *cobra.Command, _ []string) (err error) { //nolint:gocyclo,gocognit // batch plugin update with per-plugin error handling
+func runPluginUpdate(cmd *cobra.Command, args []string) (err error) { //nolint:gocyclo,gocognit // batch plugin update with per-plugin error handling
 	items := 0
 	defer func() { sendPluginSubcommandResult("update", "", items, err) }()
 
@@ -561,7 +612,6 @@ func runPluginUpdate(cmd *cobra.Command, _ []string) (err error) { //nolint:gocy
 		fmt.Println("No external plugins found in manifest")
 		return nil
 	}
-	items = len(lock.ExternalPlugins)
 
 	if verbose {
 		fmt.Fprintf(os.Stderr, "Using manifest: %s\n", manifestPath)
@@ -582,18 +632,20 @@ func runPluginUpdate(cmd *cobra.Command, _ []string) (err error) { //nolint:gocy
 	fmt.Fprintln(os.Stderr)
 	table := NewTable([]string{"PLUGIN", "STATUS"}).SetLive(true).WithWriter(os.Stderr)
 
-	// Get sorted plugin names
-	pluginNames := make([]string, 0, len(lock.ExternalPlugins))
-	for name := range lock.ExternalPlugins {
-		pluginNames = append(pluginNames, name)
+	// Get sorted plugin names, restricted to the ones named on the
+	// command line when any were given.
+	pluginNames, err := selectPluginsToUpdate(lock, args)
+	if err != nil {
+		return err
 	}
-	sort.Strings(pluginNames)
 
 	// Initialize all rows with "Queued" status
 	// In live mode, rendering is deferred until Finish() is called
 	for _, name := range pluginNames {
 		table.AddRowWithID(name, []string{name, "Queued"})
 	}
+
+	items = len(pluginNames)
 
 	// Update each external plugin
 	successCount := 0
@@ -623,6 +675,13 @@ func runPluginUpdate(cmd *cobra.Command, _ []string) (err error) { //nolint:gocy
 			switch {
 			case meta.Source != nil && meta.Source.URL != "":
 				sourceForInstall = meta.Source.URL
+			case meta.Source != nil && meta.Source.OriginalPath != "":
+				// Local sources record where they were installed from in
+				// OriginalPath, not URL. Without this, every plugin added
+				// with `tinct plugins add ./some/binary` reported "No
+				// source information" and could never be updated — even
+				// though the manifest knew exactly where it came from.
+				sourceForInstall = meta.Source.OriginalPath
 			case meta.SourceLegacy != "":
 				sourceForInstall = meta.SourceLegacy
 			default:

--- a/internal/cli/plugin_update_select_test.go
+++ b/internal/cli/plugin_update_select_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func testManifest(names ...string) *PluginManifest {
+	m := &PluginManifest{ExternalPlugins: map[string]*ExternalPluginMeta{}}
+	for _, n := range names {
+		m.ExternalPlugins[n] = &ExternalPluginMeta{Name: n}
+	}
+	return m
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// The regression: `tinct plugins update <name>` previously ignored the
+// name and updated every plugin in the manifest.
+func TestSelectPluginsToUpdate(t *testing.T) {
+	lock := testManifest("zed", "noctalia", "random", "wob")
+
+	tests := []struct {
+		name  string
+		names []string
+		want  []string
+	}{
+		{
+			name:  "no names updates everything, sorted",
+			names: nil,
+			want:  []string{"noctalia", "random", "wob", "zed"},
+		},
+		{
+			name:  "one name updates only that plugin",
+			names: []string{"random"},
+			want:  []string{"random"},
+		},
+		{
+			name:  "several names, sorted",
+			names: []string{"zed", "noctalia"},
+			want:  []string{"noctalia", "zed"},
+		},
+		{
+			name:  "duplicates collapse",
+			names: []string{"zed", "zed"},
+			want:  []string{"zed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectPluginsToUpdate(lock, tt.names)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equal(got, tt.want) {
+				t.Errorf("selected %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// An unknown name must fail loudly rather than silently updating
+// everything, which is what made the old behaviour so surprising.
+func TestSelectPluginsToUpdateRejectsUnknown(t *testing.T) {
+	lock := testManifest("zed", "noctalia")
+
+	got, err := selectPluginsToUpdate(lock, []string{"nope"})
+	if err == nil {
+		t.Fatalf("expected an error, got selection %v", got)
+	}
+	for _, want := range []string{"nope", "noctalia", "zed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q, want it to mention %q", err.Error(), want)
+		}
+	}
+}
+
+// A known name alongside an unknown one must still fail — partially
+// applying the request would be worse than refusing it.
+func TestSelectPluginsToUpdateRejectsMixedUnknown(t *testing.T) {
+	lock := testManifest("zed")
+
+	if _, err := selectPluginsToUpdate(lock, []string{"zed", "nope"}); err == nil {
+		t.Fatal("expected an error when one of several names is unknown")
+	}
+}


### PR DESCRIPTION
## `update <name>` ignored the name

```
$ tinct plugins update random

PLUGIN          STATUS
--------------  ---------------
keylightd-tray  0.1.2 → 0.4.2
noctalia        Updated (0.3.0)
random          0.1.2 → 0.4.2
wob             0.1.2 → 0.4.2
zed             0.1.2 → 0.4.2
```

The command was declared as `Use: "update"` with no `Args:` validator, and `runPluginUpdate` never read `args`. Cobra accepts arbitrary positional arguments by default, so `random` was parsed, discarded, and every plugin in the manifest was updated.

Surprising on its own, and slow when you want one plugin refreshed. It also matters because the incompatible-plugin message added in 5ae7cd0 tells users to run exactly this form.

Named plugins are now updated on their own; with no names the behaviour is unchanged. An unknown name is an error listing what is installed, rather than a silent full update:

```
$ tinct plugins update nope
Error: unknown plugin "nope" (installed: keylightd-tray, noctalia, random, wob, zed)
```

## Local sources could never be updated

Found while verifying the above. Local sources record their origin in `source.original_path`, but the update path only consulted `Source.URL` and `SourceLegacy`:

```go
case meta.Source != nil && meta.Source.URL != "":
    sourceForInstall = meta.Source.URL
case meta.SourceLegacy != "":
    sourceForInstall = meta.SourceLegacy
default:
    // "✗ No source information"
```

So every plugin added with `tinct plugins add ./binary` reported **"No source information"** and could never be updated, despite the manifest knowing exactly where it came from — `formatPluginSourceDisplay` already maps `sourceTypeLocal → source.OriginalPath`. Confirmed pre-existing against merged `main`.

Before / after for a local-source plugin:

```
noctalia  ✗ No source information     →     noctalia  Updated (0.3.0)
```

## Tests

`selectPluginsToUpdate` covers: no names updates everything (sorted), one name selects only that plugin, several names, duplicates collapse, unknown name errors and names what is installed, and a known+unknown mix still fails rather than partially applying.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV