### PR TITLE
fix(noctalia): reload the shell after writing the palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 ### Fixed
 
+- The noctalia output plugin now reloads the running shell after writing the palette. Noctalia does not watch `~/.config/noctalia/palettes/` — its inotify watch is non-recursive and only reacts to `*.toml` — so a regenerated palette never reached the running shell and the colours stayed as they were at startup. The plugin declares a `hooks.Spec` reload running `noctalia msg config-reload`, with `noctalia` as an optional binary.
+
 - `tinct plugins update <name>` now updates only the named plugin. The command declared no positional arguments and never read them, so cobra accepted the name, discarded it, and updated every plugin in the manifest. An unknown name is now an error listing what is installed, rather than a silent full update.
 - `tinct plugins update` can update plugins added from a local path. Local sources record their origin in `source.original_path`, which the update path never consulted — so every plugin installed with `tinct plugins add ./binary` reported "No source information" and could never be updated.
 

--- a/contrib/plugins/output/noctalia/README.md
+++ b/contrib/plugins/output/noctalia/README.md
@@ -9,17 +9,18 @@ plugin:
   source: external
   app: Noctalia
   app_url: https://github.com/noctalia-dev/noctalia-shell
-  version: 0.1.0
+  version: 0.2.0
   protocol_version: 0.3.0
   repository: https://github.com/jmylchreest/tinct
   install: tinct plugins install noctalia
   requires: []
-  optional: []
+  optional: [noctalia]
   pattern: single-file
   default_output_dir: ~/.config/noctalia/palettes
   generated_files: [tinct.json]
   reload:
-    method: watch
+    method: ipc
+    command: noctalia msg config-reload
     user_action_required: false
 ---
 
@@ -95,7 +96,19 @@ Both `dark` and `light` variants are written in one file when tinct produces a d
 
 ### Automatic
 
-Noctalia v5 watches its config and palette files and **hot-reloads** the active palette when `tinct.json` changes — no action required.
+After writing the palette the plugin runs:
+
+```bash
+noctalia msg config-reload
+```
+
+That forces a config reload, which re-runs Noctalia's theme resolution and — with `source = "custom"` — re-reads `tinct.json` from disk. No user action required.
+
+The reload is declared as a `hooks.Spec` reload verb, so tinct's shared hook runner owns it: `noctalia` is an **optional** binary (the plugin detects Noctalia by config directory, not by binary, so you can still generate into a config tree for another machine), the command runs under a timeout, and a missing binary or a shell that isn't running is a non-fatal no-op.
+
+**Why a reload is needed at all:** Noctalia does *not* watch the palette file. It inotifies `~/.config/noctalia` non-recursively and only treats a changed `*.toml` as a config change — `palettes/tinct.json` misses on both counts (subdirectory, and not TOML). Without the nudge the file is rewritten and the running shell keeps the colours it resolved at startup.
+
+`noctalia msg color-scheme-set custom tinct` also re-reads the palette, but it **persists** the selection into `~/.local/state/noctalia/settings.toml`, which then shadows your own config. Prefer `config-reload`.
 
 ### Manual fallback
 
@@ -135,11 +148,21 @@ This writes `templates/palette.json.tmpl`, rendered once per variant. tinct uses
 
 ### Colours unchanged after generating
 
-Noctalia is still on its wallpaper/builtin generator. Set `[theme] source = "custom"` and `custom_palette = "tinct"` (v5), or select the scheme in Settings (v4).
+Noctalia is still on its wallpaper/builtin generator. Set `[theme] source = "custom"` and `custom_palette = "tinct"` (v5), or select the scheme in Settings (v4). Check with:
 
-### Plugin skipped ("Noctalia not installed")
+```bash
+noctalia msg color-scheme-get      # expect: custom tinct
+```
 
-The plugin skips when `~/.config/noctalia` does not exist. Create it, or pass an explicit `--noctalia.output-dir`.
+If that already reports `custom tinct`, the reload did not reach the shell. Run `noctalia msg config-reload` by hand: if the colours change, `noctalia` was not on `$PATH` during the generate (`tinct generate ... -o noctalia --verbose` warns about the missing optional binary).
+
+### `custom palette 'tinct' not found or invalid`
+
+Noctalia logs this and falls back to the builtin palette when it cannot read or parse the file. Check that `~/.config/noctalia/palettes/tinct.json` exists, is readable by your user, and contains a `dark` key.
+
+### Plugin skipped ("required directory does not exist")
+
+Detection is by config directory: the plugin declares `~/.config/noctalia` (or `$NOCTALIA_CONFIG_HOME` / `$XDG_CONFIG_HOME/noctalia`) as a required directory, and tinct's hook runner skips the plugin when it is absent. Create the directory to enable the plugin.
 
 ## Related plugins
 

--- a/contrib/plugins/output/noctalia/main.go
+++ b/contrib/plugins/output/noctalia/main.go
@@ -13,7 +13,7 @@ import (
 var (
 	// Version is the semantic version of the plugin.
 	// Injected at build time via: -ldflags "-X main.Version=x.y.z"
-	Version = "0.1.0"
+	Version = "0.2.0"
 
 	// Commit is the git commit hash of the build.
 	// Injected at build time via: -ldflags "-X main.Commit=$(git rev-parse HEAD)"

--- a/contrib/plugins/output/noctalia/plugin.go
+++ b/contrib/plugins/output/noctalia/plugin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jmylchreest/tinct/pkg/colour"
 	tinctplugin "github.com/jmylchreest/tinct/pkg/plugin"
+	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 	tincttemplate "github.com/jmylchreest/tinct/pkg/template"
 )
 
@@ -37,22 +38,27 @@ type Plugin struct {
 	outputDir string
 }
 
-// noctaliaConfigDir returns ~/.config/noctalia (honouring NOCTALIA_CONFIG_HOME
-// then XDG_CONFIG_HOME), and whether the directory currently exists.
-func noctaliaConfigDir() (dir string, exists bool) {
+// noctaliaConfigDir resolves Noctalia's config directory, honouring
+// NOCTALIA_CONFIG_HOME then XDG_CONFIG_HOME before falling back to
+// ~/.config/noctalia. It returns the path whether or not it exists —
+// existence is the hook runner's business (see Hooks) — or "" when even
+// the home directory cannot be determined.
+//
+// This stays a local helper rather than a hooks.Spec literal because
+// RequiredDirs paths are only ~-expanded by the runner; it has no
+// env-var expansion, so the XDG chain has to be resolved here.
+func noctaliaConfigDir() string {
 	if c := os.Getenv("NOCTALIA_CONFIG_HOME"); c != "" {
-		dir = c
-	} else if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
-		dir = filepath.Join(x, "noctalia")
-	} else {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", false
-		}
-		dir = filepath.Join(home, ".config", "noctalia")
+		return c
 	}
-	_, err := os.Stat(dir)
-	return dir, err == nil
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "noctalia")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "noctalia")
 }
 
 // resolveOutputDir returns the palettes directory to write into.
@@ -60,7 +66,7 @@ func (p *Plugin) resolveOutputDir() (string, error) {
 	if p.outputDir != "" {
 		return p.outputDir, nil
 	}
-	dir, _ := noctaliaConfigDir()
+	dir := noctaliaConfigDir()
 	if dir == "" {
 		return "", fmt.Errorf("failed to resolve noctalia config directory")
 	}
@@ -181,21 +187,64 @@ func renderVariant(tmpl *template.Template, themeData *colour.ThemeData) (map[st
 	return obj, nil
 }
 
-// PreExecute skips the plugin when Noctalia is not installed (no config dir).
+// PreExecute is a no-op — the "is Noctalia installed?" check is declared
+// in Hooks() as a RequiredDirs entry, which the host's shared runner
+// evaluates before this method is called.
 func (p *Plugin) PreExecute(_ context.Context) (skip bool, reason string, err error) {
-	if p.outputDir != "" {
-		return false, "", nil
-	}
-	if _, exists := noctaliaConfigDir(); !exists {
-		return true, "Noctalia not installed (config directory does not exist)", nil
-	}
 	return false, "", nil
 }
 
-// PostExecute is a no-op: Noctalia v5 watches its config/palette files and
-// hot-reloads automatically when the palette changes.
+// PostExecute is a no-op — the reload is declared statically in Hooks()
+// so the host's shared runner owns the binary check and the timeout.
 func (p *Plugin) PostExecute(_ context.Context, _ []string) error {
 	return nil
+}
+
+// Hooks declares Noctalia's static post-execute behaviour.
+//
+// Noctalia v5 does NOT pick up palette changes on its own. It inotifies
+// ~/.config/noctalia (and ~/.local/state/noctalia) non-recursively and
+// only treats a changed *.toml as a config change. The palette misses on
+// both counts: palettes/ is a subdirectory, and tinct.json is not TOML.
+// So a regenerated palette produces no event and the running shell keeps
+// the colours it resolved at startup.
+//
+// `noctalia msg config-reload` forces a config reload, which re-runs the
+// theme resolution and — for a custom palette source — re-reads the JSON
+// from disk. That is the whole fix, so it is the reload verb here.
+//
+// The binary is optional rather than required: the plugin detects
+// Noctalia by config directory (see PreExecute), which lets users
+// generate into a config tree for a machine where the binary is absent.
+// The host runner warns about the missing binary in verbose mode and the
+// exec verb is a non-fatal no-op when it cannot be found.
+//
+// `color-scheme-set custom <name>` also re-reads the file, but persists a
+// theme override into ~/.local/state/noctalia/settings.toml that then
+// shadows the user's own config — config-reload has no such side effect.
+//
+// Detection is by config directory, declared as RequiredDirs so the
+// shared runner skips the plugin (with a consistent reason string) when
+// Noctalia is not installed. The path is resolved here rather than
+// written as a "~/.config/noctalia" literal because the runner does not
+// expand environment variables — see noctaliaConfigDir.
+//
+// Implements tinctplugin.HooksProvider (protocol 0.3.0+).
+func (p *Plugin) Hooks() hooks.Spec {
+	spec := hooks.Spec{
+		OptionalBinaries: []string{"noctalia"},
+		Reload: &hooks.ReloadSpec{
+			Verb: hooks.VerbExec,
+			Args: []string{"noctalia", "msg", "config-reload"},
+		},
+	}
+	// An unresolvable config dir is left to Generate, which fails with a
+	// specific error; declaring RequiredDirs{""} would skip the plugin
+	// with a truncated, confusing reason instead.
+	if dir := noctaliaConfigDir(); dir != "" {
+		spec.RequiredDirs = []string{dir}
+	}
+	return spec
 }
 
 // Templates exposes the embedded template so `tinct plugins templates dump`
@@ -228,13 +277,16 @@ func (p *Plugin) GetMetadata() tinctplugin.PluginInfo {
 		Metadata: &tinctplugin.Metadata{
 			// Noctalia detection is by config-directory presence
 			// (~/.config/noctalia); no binary on PATH is required.
+			OptionalBinaries: []string{"noctalia"},
 			DefaultOutputDir: "~/.config/noctalia/palettes",
 			GeneratedFiles:   []string{"tinct.json"},
 			Pattern:          "single-file",
 			Reload: &tinctplugin.ReloadMetadata{
-				// Noctalia v5 watches its config/palette files and reloads
-				// the active palette live when the file changes.
-				Method:             "watch",
+				// Noctalia does not watch the palettes directory, so the
+				// declarative hook in Hooks() nudges the running shell to
+				// re-resolve the palette from disk.
+				Method:             "ipc",
+				Command:            "noctalia msg config-reload",
 				UserActionRequired: false,
 			},
 		},

--- a/contrib/plugins/output/noctalia/plugin_test.go
+++ b/contrib/plugins/output/noctalia/plugin_test.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
 	tinctplugin "github.com/jmylchreest/tinct/pkg/plugin"
+	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 )
 
 var hexRe = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
@@ -170,11 +172,110 @@ func TestMetadata(t *testing.T) {
 	if m.Type != "output" {
 		t.Errorf("Type = %q, want output", m.Type)
 	}
-	if m.Metadata == nil || m.Metadata.Reload == nil || m.Metadata.Reload.Method != "watch" {
-		t.Errorf("expected reload method 'watch', got %+v", m.Metadata)
+	if m.Metadata == nil || m.Metadata.Reload == nil || m.Metadata.Reload.Method != "ipc" {
+		t.Errorf("expected reload method 'ipc', got %+v", m.Metadata)
+	}
+	if m.Metadata.Reload.Command != "noctalia msg config-reload" {
+		t.Errorf("Reload.Command = %q, want 'noctalia msg config-reload'", m.Metadata.Reload.Command)
 	}
 	if !strings.Contains(m.Metadata.DefaultOutputDir, "noctalia") {
 		t.Errorf("DefaultOutputDir = %q, want it to contain noctalia", m.Metadata.DefaultOutputDir)
+	}
+}
+
+// TestHooksDeclaresReload guards the reload contract: Noctalia does not
+// watch its palettes directory, so a regenerated palette only takes
+// effect if the running shell is told to re-read it.
+func TestHooksDeclaresReload(t *testing.T) {
+	spec := (&Plugin{}).Hooks()
+
+	if spec.Reload == nil {
+		t.Fatal("Hooks().Reload is nil; the palette would never be reloaded")
+	}
+	if spec.Reload.Verb != hooks.VerbExec {
+		t.Errorf("Reload.Verb = %q, want %q", spec.Reload.Verb, hooks.VerbExec)
+	}
+	want := []string{"noctalia", "msg", "config-reload"}
+	if !slices.Equal(spec.Reload.Args, want) {
+		t.Errorf("Reload.Args = %v, want %v", spec.Reload.Args, want)
+	}
+
+	// The binary guard must be optional, not required: detection is by
+	// config directory, so generating for a machine without the binary
+	// must still write the palette.
+	if !slices.Contains(spec.OptionalBinaries, "noctalia") {
+		t.Errorf("OptionalBinaries = %v, want it to contain noctalia", spec.OptionalBinaries)
+	}
+	if len(spec.RequiredBinaries) != 0 {
+		t.Errorf("RequiredBinaries = %v, want none", spec.RequiredBinaries)
+	}
+}
+
+// TestHooksDeclaresConfigDir checks that installation detection is
+// declarative (RequiredDirs) rather than hand-rolled in PreExecute, and
+// that the declared path follows the NOCTALIA_CONFIG_HOME / XDG chain —
+// the hook runner only expands ~, so the resolution has to happen here.
+func TestHooksDeclaresConfigDir(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "NOCTALIA_CONFIG_HOME wins",
+			env:  map[string]string{"NOCTALIA_CONFIG_HOME": "/custom/noctalia", "XDG_CONFIG_HOME": "/xdg"},
+			want: "/custom/noctalia",
+		},
+		{
+			name: "XDG_CONFIG_HOME is next",
+			env:  map[string]string{"XDG_CONFIG_HOME": "/xdg"},
+			want: filepath.Join("/xdg", "noctalia"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NOCTALIA_CONFIG_HOME", "")
+			t.Setenv("XDG_CONFIG_HOME", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			spec := (&Plugin{}).Hooks()
+			if !slices.Equal(spec.RequiredDirs, []string{tt.want}) {
+				t.Errorf("RequiredDirs = %v, want [%s]", spec.RequiredDirs, tt.want)
+			}
+		})
+	}
+}
+
+// TestPreExecuteNeverSkips locks in that the skip decision moved to the
+// hook runner: a PreExecute that still gated would double up on (and
+// could contradict) the RequiredDirs check.
+func TestPreExecuteNeverSkips(t *testing.T) {
+	t.Setenv("NOCTALIA_CONFIG_HOME", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	skip, reason, err := (&Plugin{}).PreExecute(context.Background())
+	if err != nil {
+		t.Fatalf("PreExecute returned error: %v", err)
+	}
+	if skip {
+		t.Errorf("PreExecute skipped (%q); the RequiredDirs hook owns that decision", reason)
+	}
+}
+
+// TestMetadataMatchesHooks keeps the documented reload (used for README
+// frontmatter drift checks) in step with what the runner actually does.
+func TestMetadataMatchesHooks(t *testing.T) {
+	p := &Plugin{}
+	meta := p.GetMetadata().Metadata
+	spec := p.Hooks()
+
+	if got, want := meta.Reload.Command, strings.Join(spec.Reload.Args, " "); got != want {
+		t.Errorf("metadata reload command = %q, hooks run %q", got, want)
+	}
+	if !slices.Equal(meta.OptionalBinaries, spec.OptionalBinaries) {
+		t.Errorf("metadata OptionalBinaries = %v, hooks declare %v", meta.OptionalBinaries, spec.OptionalBinaries)
 	}
 }
 

--- a/docs/docs/plugins/output/bars-launchers/noctalia.md
+++ b/docs/docs/plugins/output/bars-launchers/noctalia.md
@@ -8,18 +8,20 @@ plugin:
   source: external
   app: Noctalia
   app_url: 'https://github.com/noctalia-dev/noctalia-shell'
-  version: 0.1.0
+  version: 0.2.0
   protocol_version: 0.3.0
   repository: 'https://github.com/jmylchreest/tinct'
   install: tinct plugins install noctalia
   requires: []
-  optional: []
+  optional:
+    - noctalia
   pattern: single-file
   default_output_dir: ~/.config/noctalia/palettes
   generated_files:
     - tinct.json
   reload:
-    method: watch
+    method: ipc
+    command: noctalia msg config-reload
     user_action_required: false
 ---
 
@@ -95,7 +97,19 @@ Both `dark` and `light` variants are written in one file when tinct produces a d
 
 ### Automatic
 
-Noctalia v5 watches its config and palette files and **hot-reloads** the active palette when `tinct.json` changes — no action required.
+After writing the palette the plugin runs:
+
+```bash
+noctalia msg config-reload
+```
+
+That forces a config reload, which re-runs Noctalia's theme resolution and — with `source = "custom"` — re-reads `tinct.json` from disk. No user action required.
+
+The reload is declared as a `hooks.Spec` reload verb, so tinct's shared hook runner owns it: `noctalia` is an **optional** binary (the plugin detects Noctalia by config directory, not by binary, so you can still generate into a config tree for another machine), the command runs under a timeout, and a missing binary or a shell that isn't running is a non-fatal no-op.
+
+**Why a reload is needed at all:** Noctalia does *not* watch the palette file. It inotifies `~/.config/noctalia` non-recursively and only treats a changed `*.toml` as a config change — `palettes/tinct.json` misses on both counts (subdirectory, and not TOML). Without the nudge the file is rewritten and the running shell keeps the colours it resolved at startup.
+
+`noctalia msg color-scheme-set custom tinct` also re-reads the palette, but it **persists** the selection into `~/.local/state/noctalia/settings.toml`, which then shadows your own config. Prefer `config-reload`.
 
 ### Manual fallback
 
@@ -135,11 +149,21 @@ This writes `templates/palette.json.tmpl`, rendered once per variant. tinct uses
 
 ### Colours unchanged after generating
 
-Noctalia is still on its wallpaper/builtin generator. Set `[theme] source = "custom"` and `custom_palette = "tinct"` (v5), or select the scheme in Settings (v4).
+Noctalia is still on its wallpaper/builtin generator. Set `[theme] source = "custom"` and `custom_palette = "tinct"` (v5), or select the scheme in Settings (v4). Check with:
 
-### Plugin skipped ("Noctalia not installed")
+```bash
+noctalia msg color-scheme-get      # expect: custom tinct
+```
 
-The plugin skips when `~/.config/noctalia` does not exist. Create it, or pass an explicit `--noctalia.output-dir`.
+If that already reports `custom tinct`, the reload did not reach the shell. Run `noctalia msg config-reload` by hand: if the colours change, `noctalia` was not on `$PATH` during the generate (`tinct generate ... -o noctalia --verbose` warns about the missing optional binary).
+
+### `custom palette 'tinct' not found or invalid`
+
+Noctalia logs this and falls back to the builtin palette when it cannot read or parse the file. Check that `~/.config/noctalia/palettes/tinct.json` exists, is readable by your user, and contains a `dark` key.
+
+### Plugin skipped ("required directory does not exist")
+
+Detection is by config directory: the plugin declares `~/.config/noctalia` (or `$NOCTALIA_CONFIG_HOME` / `$XDG_CONFIG_HOME/noctalia`) as a required directory, and tinct's hook runner skips the plugin when it is absent. Create the directory to enable the plugin.
 
 ## Related plugins
 


### PR DESCRIPTION
`tinct generate -o noctalia` rewrote `~/.config/noctalia/palettes/tinct.json` and the running shell kept the colours it resolved at startup.

## Noctalia never sees the write

Dumping the running process's inotify watches (`/proc/<pid>/fdinfo`) and resolving the inodes:

| watched inode | path |
|---|---|
| `355a178` | `~/.config/noctalia` (dir, **non-recursive**) |
| `356130b` | `~/.local/state/noctalia` (dir, non-recursive) |
| `35612f2`, `356282c` | two plugin dirs |

`~/.config/noctalia/palettes` (inode `355a179`) and `tinct.json` (`355a17a`) appear **nowhere**. And Noctalia only treats a changed `*.toml` as a config change, so the palette misses on both counts: `palettes/` is a subdirectory, and `tinct.json` is not TOML. The write produces no event at all — no debounce, no race.

Confirmed from the other direction too: `chmod 000` on the palette followed by a forced reload logs

```
[WRN] [theme] custom palette 'tinct' not found or invalid; falling back to builtin
```

so the file *is* read on reload — it just never gets told to reload.

The plugin asserted the opposite. `PostExecute` was a deliberate no-op commented *"Noctalia v5 watches its config/palette files and hot-reloads automatically"*, and the metadata advertised `reload: watch` with `user_action_required: false`.

## Fix

A `hooks.Spec` reload verb running `noctalia msg config-reload`, which forces a config reload — re-running theme resolution and, for a custom palette source, re-reading the JSON from disk. Declared rather than hand-rolled, so the shared runner owns the binary check and the timeout, and `noctalia` is an **optional** binary because the plugin detects Noctalia by config directory, not by binary.

Not `color-scheme-set custom <name>`: it also re-reads the palette, but persists a theme override into `~/.local/state/noctalia/settings.toml` that then shadows the user's own config.

Verified end to end:

```
palette written   12:13:00.637   ~/.config/noctalia/palettes/tinct.json
→ Running noctalia post-hook…   12:13:00.719 – .725
noctalia[16574]:  12:13:00.750  [INF] [wallpaper] reloading config
```

And that the colours actually apply: forcing `mPrimary` to `#00ff00` and reloading turned the bar green instantly.

## Also: detection moves onto the declarative spec

The installation check moves off the hand-rolled `PreExecute` onto `RequiredDirs`, matching gtk3/gtk4/waybar/niri/hyprland. The `NOCTALIA_CONFIG_HOME` → `XDG_CONFIG_HOME` chain still resolves in the plugin, because the hook runner only expands `~`.

```
NOCTALIA_CONFIG_HOME=/nonexistent tinct generate … -o noctalia --verbose
⊘ Skipping noctalia: required directory does not exist: /nonexistent
```

## Tests

Reload contract (verb, args, optional-not-required binary), the env-var resolution chain, and that `PreExecute` no longer gates — so it can't drift back or contradict the declarative check. README/docs updated; `tinct-check-readmes` reports 0 warnings.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV