### PR TITLE
perf(plugins): reuse one plugin subprocess per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,18 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 ## [Unreleased]
 
+### Added
+
+- Optional `Configurable` plugin interface and `Plugin.Configure` RPC. The host pushes args, dry-run and verbose into a plugin before the pre-execute lifecycle, so `PreExecute` and `Hooks` can honour flags instead of assuming defaults. Plugins that do not implement it are unaffected — unknown-method errors fall back like `Validate` and `GetHooks`.
+
+### Changed
+
+- External plugins keep one subprocess for a whole run instead of spawning a fresh one per RPC. A full generate went from ~25 plugin launches to 3 (5 to 1 for a single-plugin run), which also all but removes the stray `yamux: Failed to write header` lines those teardowns produced.
+
 ### Fixed
+
+- `--noctalia.output-dir` was accepted and silently ignored — the plugin never read `PaletteData.PluginArgs` and its output directory was never assigned. It now arrives via `Configure` before `Hooks`/`PreExecute`, expands `~`, and suppresses the config-directory check when set.
+- External input plugins no longer lose their debug output under `--verbose`. Verbose is set on the plugin before `Validate`, which is the first RPC and therefore the call that starts the subprocess whose logger is fixed for its lifetime.
 
 - The noctalia output plugin now reloads the running shell after writing the palette. Noctalia does not watch `~/.config/noctalia/palettes/` — its inotify watch is non-recursive and only reacts to `*.toml` — so a regenerated palette never reached the running shell and the colours stayed as they were at startup. The plugin declares a `hooks.Spec` reload running `noctalia msg config-reload`, with `noctalia` as an optional binary.
 

--- a/contrib/plugins/output/noctalia/README.md
+++ b/contrib/plugins/output/noctalia/README.md
@@ -9,7 +9,7 @@ plugin:
   source: external
   app: Noctalia
   app_url: https://github.com/noctalia-dev/noctalia-shell
-  version: 0.2.0
+  version: 0.3.0
   protocol_version: 0.3.0
   repository: https://github.com/jmylchreest/tinct
   install: tinct plugins install noctalia
@@ -162,7 +162,7 @@ Noctalia logs this and falls back to the builtin palette when it cannot read or 
 
 ### Plugin skipped ("required directory does not exist")
 
-Detection is by config directory: the plugin declares `~/.config/noctalia` (or `$NOCTALIA_CONFIG_HOME` / `$XDG_CONFIG_HOME/noctalia`) as a required directory, and tinct's hook runner skips the plugin when it is absent. Create the directory to enable the plugin.
+Detection is by config directory: the plugin declares `~/.config/noctalia` (or `$NOCTALIA_CONFIG_HOME` / `$XDG_CONFIG_HOME/noctalia`) as a required directory, and tinct's hook runner skips the plugin when it is absent. Create the directory to enable the plugin, or pass `--noctalia.output-dir` — an explicit destination disables the config-directory check, which is how you generate for a machine that has no Noctalia install of its own.
 
 ## Related plugins
 

--- a/contrib/plugins/output/noctalia/main.go
+++ b/contrib/plugins/output/noctalia/main.go
@@ -13,7 +13,7 @@ import (
 var (
 	// Version is the semantic version of the plugin.
 	// Injected at build time via: -ldflags "-X main.Version=x.y.z"
-	Version = "0.2.0"
+	Version = "0.3.0"
 
 	// Commit is the git commit hash of the build.
 	// Injected at build time via: -ldflags "-X main.Commit=$(git rev-parse HEAD)"

--- a/contrib/plugins/output/noctalia/plugin.go
+++ b/contrib/plugins/output/noctalia/plugin.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/jmylchreest/tinct/pkg/colour"
@@ -59,6 +60,36 @@ func noctaliaConfigDir() string {
 		return ""
 	}
 	return filepath.Join(home, ".config", "noctalia")
+}
+
+// Configure records the host's per-run configuration. It is what makes
+// --noctalia.output-dir load-bearing: the flag arrives here before
+// PreExecute and Hooks run, so the declared RequiredDirs can follow the
+// override instead of always pointing at the default config directory.
+//
+// Implements tinctplugin.Configurable (protocol 0.3.0+).
+func (p *Plugin) Configure(req tinctplugin.ConfigureRequest) error {
+	if dir, ok := req.Args["output-dir"].(string); ok && dir != "" {
+		p.outputDir = expandTilde(dir)
+	}
+	return nil
+}
+
+// expandTilde expands a leading ~ so a flag value can be written in the
+// shell-style form users expect. The host does not expand it for us —
+// plugin args arrive as literal strings.
+func expandTilde(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, path[2:])
 }
 
 // resolveOutputDir returns the palettes directory to write into.
@@ -238,6 +269,14 @@ func (p *Plugin) Hooks() hooks.Spec {
 			Args: []string{"noctalia", "msg", "config-reload"},
 		},
 	}
+	// With an explicit --noctalia.output-dir the user has said where to
+	// write, so the config-directory check would be wrong — that is the
+	// documented way to generate for a machine that has no Noctalia
+	// install of its own.
+	if p.outputDir != "" {
+		return spec
+	}
+
 	// An unresolvable config dir is left to Generate, which fails with a
 	// specific error; declaring RequiredDirs{""} would skip the plugin
 	// with a truncated, confusing reason instead.

--- a/contrib/plugins/output/noctalia/plugin_test.go
+++ b/contrib/plugins/output/noctalia/plugin_test.go
@@ -286,3 +286,77 @@ func keys(m map[string][]byte) []string {
 	}
 	return out
 }
+
+// TestConfigureSetsOutputDir covers the wiring that makes
+// --noctalia.output-dir load-bearing: the host delivers args via
+// Configure before PreExecute/Hooks, and the plugin must record them.
+func TestConfigureSetsOutputDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{name: "absolute path", args: map[string]any{"output-dir": "/tmp/palettes"}, want: "/tmp/palettes"},
+		{name: "tilde is expanded", args: map[string]any{"output-dir": "~/pal"}, want: filepath.Join(home, "pal")},
+		{name: "empty value ignored", args: map[string]any{"output-dir": ""}, want: ""},
+		{name: "wrong type ignored", args: map[string]any{"output-dir": 42}, want: ""},
+		{name: "absent key ignored", args: map[string]any{}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{}
+			if err := p.Configure(tinctplugin.ConfigureRequest{Args: tt.args}); err != nil {
+				t.Fatalf("Configure returned error: %v", err)
+			}
+			if p.outputDir != tt.want {
+				t.Errorf("outputDir = %q, want %q", p.outputDir, tt.want)
+			}
+		})
+	}
+}
+
+// An explicit output dir means the user chose the destination, so the
+// config-directory check must not skip the plugin — that is how you
+// generate for a machine with no Noctalia install.
+func TestHooksSkipsConfigDirCheckWhenOutputDirOverridden(t *testing.T) {
+	t.Setenv("NOCTALIA_CONFIG_HOME", filepath.Join(t.TempDir(), "absent"))
+
+	p := &Plugin{}
+	if got := p.Hooks(); len(got.RequiredDirs) == 0 {
+		t.Fatal("expected a RequiredDirs check without an output-dir override")
+	}
+
+	if err := p.Configure(tinctplugin.ConfigureRequest{
+		Args: map[string]any{"output-dir": t.TempDir()},
+	}); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+	if got := p.Hooks(); len(got.RequiredDirs) != 0 {
+		t.Errorf("RequiredDirs = %v, want none when output-dir is overridden", got.RequiredDirs)
+	}
+}
+
+// Generate must write to the configured directory, not the default.
+func TestGenerateHonoursConfiguredOutputDir(t *testing.T) {
+	dir := t.TempDir()
+	p := &Plugin{}
+	if err := p.Configure(tinctplugin.ConfigureRequest{Args: map[string]any{"output-dir": dir}}); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+
+	files, err := p.Generate(context.Background(), testPalette("dark"))
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	want := filepath.Join(dir, "tinct.json")
+	if _, ok := files[want]; !ok {
+		t.Errorf("Generate wrote %v, want a file at %s", keys(files), want)
+	}
+}

--- a/docs/docs/plugins/output/bars-launchers/noctalia.md
+++ b/docs/docs/plugins/output/bars-launchers/noctalia.md
@@ -8,7 +8,7 @@ plugin:
   source: external
   app: Noctalia
   app_url: 'https://github.com/noctalia-dev/noctalia-shell'
-  version: 0.2.0
+  version: 0.3.0
   protocol_version: 0.3.0
   repository: 'https://github.com/jmylchreest/tinct'
   install: tinct plugins install noctalia
@@ -163,7 +163,7 @@ Noctalia logs this and falls back to the builtin palette when it cannot read or 
 
 ### Plugin skipped ("required directory does not exist")
 
-Detection is by config directory: the plugin declares `~/.config/noctalia` (or `$NOCTALIA_CONFIG_HOME` / `$XDG_CONFIG_HOME/noctalia`) as a required directory, and tinct's hook runner skips the plugin when it is absent. Create the directory to enable the plugin.
+Detection is by config directory: the plugin declares `~/.config/noctalia` (or `$NOCTALIA_CONFIG_HOME` / `$XDG_CONFIG_HOME/noctalia`) as a required directory, and tinct's hook runner skips the plugin when it is absent. Create the directory to enable the plugin, or pass `--noctalia.output-dir` — an explicit destination disables the config-directory check, which is how you generate for a machine that has no Noctalia install of its own.
 
 ## Related plugins
 

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -140,6 +140,13 @@ func runGenerate(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// External plugins keep one subprocess alive across their whole
+	// call sequence (Validate → Hooks → PreExecute → Generate →
+	// PostExecute). Shut them down once the run is over, including the
+	// input plugin, whose wallpaper-path accessors are read above.
+	defer closePlugins(outputPlugins)
+	defer closePlugins([]input.Plugin{inputPlugin})
+
 	executions := preparePluginExecutions(ctx, outputPlugins)
 	successCount := generateAndWriteFiles(executions, palette, alternatePalette, wallpaperPath, wallpaperRawPath)
 
@@ -162,6 +169,20 @@ func runGenerate(cmd *cobra.Command, _ []string) error {
 
 	return summaryErr
 }
+
+// closePlugins shuts down any plugin holding a live subprocess.
+// In-tree plugins don't implement pluginCloser and are skipped.
+func closePlugins[T any](plugins []T) {
+	for _, p := range plugins {
+		if closer, ok := any(p).(pluginCloser); ok {
+			closer.Close()
+		}
+	}
+}
+
+// pluginCloser is implemented by external plugin wrappers, which cache a
+// plugin subprocess for the duration of a run.
+type pluginCloser interface{ Close() }
 
 // runGlobalHookScript executes a global hook script if it exists.
 // Looks for scripts at ~/.config/tinct/hooks/{hook-name}.sh.

--- a/internal/cli/generate_helpers.go
+++ b/internal/cli/generate_helpers.go
@@ -56,6 +56,14 @@ func getAndValidateInputPlugin() (input.Plugin, error) {
 		return nil, fmt.Errorf("unknown input plugin: %s (available: %s)", generateInputPlugin, strings.Join(availablePlugins, ", "))
 	}
 
+	// Set verbose before Validate: for external plugins Validate is the
+	// first RPC, and it starts the subprocess whose logger is fixed for
+	// the life of that process. Setting it afterwards would be too late
+	// and the run would silently lose plugin debug output.
+	if verbosePlugin, ok := plugin.(interface{ SetVerbose(bool) }); ok {
+		verbosePlugin.SetVerbose(generateVerbose)
+	}
+
 	if err := plugin.Validate(); err != nil {
 		return nil, fmt.Errorf("input plugin validation failed: %w", err)
 	}

--- a/internal/plugin/executor/executor.go
+++ b/internal/plugin/executor/executor.go
@@ -60,7 +60,7 @@ func NewWithVerboseAndRunner(pluginPath string, verbose bool, runner ProcessRunn
 	// hang on the magic-cookie exchange with no actionable error.
 	//
 	// This applies the general floor only; the per-type floor (input
-	// plugins need a newer protocol for WallpaperRawPath) is enforced at
+	// plugins need 0.2.0 for WallpaperRawPath) is enforced at
 	// registration, where the plugin's type is known.
 	//
 	// Empty versions are tolerated for backward compatibility with
@@ -188,6 +188,35 @@ func (e *PluginExecutor) Validate(ctx context.Context, pluginRole string, args m
 		return client.Validate(args)
 	default:
 		return nil
+	}
+}
+
+// Configure pushes the host's per-run configuration (args, dry-run,
+// verbose) into the plugin before any other lifecycle call, so
+// PreExecute and GetHooks can honour flags rather than assume defaults.
+//
+// kind selects the client ("input" or "output"). Failure is deliberately
+// swallowed: a plugin that cannot be configured — old SDK, no
+// Configurable implementation, JSON stdio, or a transport hiccup — must
+// still run, it just sees its args later, in Generate, as it always did.
+func (e *PluginExecutor) Configure(ctx context.Context, kind string, req plugin.ConfigureRequest) {
+	if e.protocolType != protocol.PluginTypeGoPlugin {
+		return
+	}
+
+	switch kind {
+	case "input":
+		client, err := e.getInputRPCClient(ctx)
+		if err != nil {
+			return
+		}
+		_ = client.Configure(req)
+	case "output":
+		client, err := e.getOutputRPCClient(ctx)
+		if err != nil {
+			return
+		}
+		_ = client.Configure(req)
 	}
 }
 

--- a/internal/plugin/manager/manager.go
+++ b/internal/plugin/manager/manager.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 
 	"github.com/spf13/cobra"
 
@@ -312,12 +313,85 @@ func (e *IncompatiblePluginError) Error() string {
 }
 
 // externalPluginBase holds fields and methods shared by all external plugin wrappers.
+//
+// session caches the plugin subprocess for the lifetime of one run. Every
+// RPC used to spawn its own executor and Kill() it immediately, which
+// meant a single output plugin was launched five times per generate
+// (Validate, GetHooks, PreExecute, Generate, PostExecute) — five
+// handshakes, five yamux sessions, and five chances to race the
+// teardown (the stray "yamux: Failed to write header" lines). Worse,
+// each spawn got a fresh plugin object, so anything a plugin learned in
+// one call (its args, for instance) was gone by the next.
+//
+// Reusing one process fixes both: the plugin keeps its state across the
+// call sequence, and Configure can push args in once, before the
+// pre-execute checks that need them.
 type externalPluginBase struct {
 	name        string
 	description string
 	path        string
 	args        map[string]any
 	dryRun      bool
+	// verbose must be set before the first session() call: it selects
+	// the go-plugin logger, which is fixed for the life of the
+	// subprocess. Both input and output wrappers expose SetVerbose so
+	// the CLI can set it before validation starts.
+	verbose bool
+
+	mu          sync.Mutex
+	execSession *executor.PluginExecutor
+	// configured guards the one-shot Configure RPC so re-entering
+	// session() mid-run does not re-push args.
+	configured bool
+}
+
+// session returns the cached executor, starting the plugin subprocess on
+// first use. kind is "input" or "output" and selects which Configure RPC
+// is attempted.
+//
+// Configure is optional: plugins built against older SDKs (or that do
+// not implement Configurable) report "can't find method" and the host
+// carries on, exactly as with the other optional 0.3.0+ methods. Its
+// failure is never fatal — a plugin that cannot be configured still
+// generates, it just does not see its args early.
+func (b *externalPluginBase) session(kind string) (*executor.PluginExecutor, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.execSession != nil {
+		return b.execSession, nil
+	}
+
+	pluginExec, err := executor.NewWithVerbose(b.path, b.verbose)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create plugin executor: %w", err)
+	}
+	b.execSession = pluginExec
+
+	if !b.configured {
+		b.configured = true
+		pluginExec.Configure(context.Background(), kind, plugin.ConfigureRequest{
+			Args:    b.args,
+			DryRun:  b.dryRun,
+			Verbose: b.verbose,
+		})
+	}
+
+	return b.execSession, nil
+}
+
+// Close shuts down the cached plugin subprocess. Safe to call more than
+// once and on a plugin that never started one. The host calls this when
+// a run finishes; the next session() starts a fresh process.
+func (b *externalPluginBase) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.execSession != nil {
+		b.execSession.Close()
+		b.execSession = nil
+	}
+	b.configured = false
 }
 
 // Name returns the plugin's name.
@@ -343,6 +417,14 @@ func (b *externalPluginBase) SetArgs(args map[string]any) { b.args = args }
 
 // GetArgs returns custom arguments for this plugin.
 func (b *externalPluginBase) GetArgs() map[string]any { return b.args }
+
+// SetVerbose sets the verbose flag. It only affects sessions started
+// afterwards — a running plugin subprocess keeps the logger it was
+// created with — so the host sets it before the first RPC.
+func (b *externalPluginBase) SetVerbose(verbose bool) { b.verbose = verbose }
+
+// GetVerbose returns the verbose flag.
+func (b *externalPluginBase) GetVerbose() bool { return b.verbose }
 
 // SetDryRun sets the dry-run mode for this plugin.
 func (b *externalPluginBase) SetDryRun(dryRun bool) { b.dryRun = dryRun }
@@ -387,18 +469,13 @@ func NewExternalInputPlugin(name, description, path string) *ExternalInputPlugin
 // Uses the hybrid executor which automatically detects and uses the appropriate
 // protocol (go-plugin RPC or JSON-stdio).
 func (p *ExternalInputPlugin) Generate(ctx context.Context, opts input.GenerateOptions) (*colour.Palette, error) {
-	// Close previous executor if it exists
-	if p.lastExecutor != nil {
-		p.lastExecutor.Close()
-	}
-
-	// Create executor (detects protocol automatically).
-	pluginExec, err := executor.NewWithVerbose(p.path, opts.Verbose)
+	pluginExec, err := p.session("input")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create plugin executor: %w", err)
+		return nil, err
 	}
 
-	// Store the executor so we can query wallpaper path later
+	// Kept for the wallpaper-path accessors below; the session owns the
+	// process lifetime, so this must not be closed here.
 	p.lastExecutor = pluginExec
 
 	// Merge plugin args from opts with plugin's own args.
@@ -486,11 +563,10 @@ func (p *ExternalInputPlugin) RegisterFlags(_ *cobra.Command) {
 // implement Validator (or run on JSON stdio) report success and
 // surface their errors at Generate time as before.
 func (p *ExternalInputPlugin) Validate() error {
-	pluginExec, err := executor.NewWithVerbose(p.path, false)
+	pluginExec, err := p.session("input")
 	if err != nil {
-		return fmt.Errorf("failed to create plugin executor: %w", err)
+		return err
 	}
-	defer pluginExec.Close()
 	return pluginExec.Validate(context.Background(), "input", p.args)
 }
 
@@ -531,7 +607,6 @@ func (p *ExternalInputPlugin) Close() {
 // ExternalOutputPlugin wraps an external executable as an output plugin.
 type ExternalOutputPlugin struct {
 	externalPluginBase
-	verbose          bool
 	alternatePalette *colour.CategorisedPalette
 }
 
@@ -546,16 +621,6 @@ func NewExternalOutputPlugin(name, description, path string) *ExternalOutputPlug
 	}
 }
 
-// SetVerbose sets the verbose flag for this plugin.
-func (p *ExternalOutputPlugin) SetVerbose(verbose bool) {
-	p.verbose = verbose
-}
-
-// GetVerbose returns the verbose setting for this plugin.
-func (p *ExternalOutputPlugin) GetVerbose() bool {
-	return p.verbose
-}
-
 // SetAlternatePalette sets the alternate palette for dual-theme generation.
 func (p *ExternalOutputPlugin) SetAlternatePalette(palette *colour.CategorisedPalette) {
 	p.alternatePalette = palette
@@ -563,12 +628,10 @@ func (p *ExternalOutputPlugin) SetAlternatePalette(palette *colour.CategorisedPa
 
 // Generate executes the external plugin and returns its output.
 func (p *ExternalOutputPlugin) Generate(themeData *colour.ThemeData) (map[string][]byte, error) {
-	// Create executor (detects protocol automatically).
-	pluginExec, err := executor.NewWithVerbose(p.path, p.verbose)
+	pluginExec, err := p.session("output")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create plugin executor: %w", err)
+		return nil, err
 	}
-	defer pluginExec.Close()
 
 	// Extract palette from themeData.
 	palette := themeData.Palette()
@@ -604,11 +667,10 @@ func (p *ExternalOutputPlugin) RegisterFlags(_ *cobra.Command) {
 // implement Validator (or run on JSON stdio) report success and
 // surface their errors at Generate time as before.
 func (p *ExternalOutputPlugin) Validate() error {
-	pluginExec, err := executor.NewWithVerbose(p.path, false)
+	pluginExec, err := p.session("output")
 	if err != nil {
-		return fmt.Errorf("failed to create plugin executor: %w", err)
+		return err
 	}
-	defer pluginExec.Close()
 	return pluginExec.Validate(context.Background(), "output", p.args)
 }
 
@@ -618,11 +680,10 @@ func (p *ExternalOutputPlugin) Validate() error {
 // hooks.Provider interface so the existing CLI hook runner picks up
 // external plugin specs without any extra wiring.
 func (p *ExternalOutputPlugin) Hooks() hooks.Spec {
-	pluginExec, err := executor.NewWithVerbose(p.path, p.verbose)
+	pluginExec, err := p.session("output")
 	if err != nil {
 		return hooks.Spec{}
 	}
-	defer pluginExec.Close()
 	spec, _ := pluginExec.GetHooks(context.Background())
 	return spec
 }
@@ -653,12 +714,10 @@ func (p *ExternalOutputPlugin) DefaultOutputDir() string {
 // PreExecute calls the external plugin's pre-execute hook.
 // Implements the output.PreExecuteHook interface.
 func (p *ExternalOutputPlugin) PreExecute(ctx context.Context) (skip bool, reason string, err error) {
-	// Create executor (detects protocol automatically).
-	pluginExec, err := executor.NewWithVerbose(p.path, p.verbose)
+	pluginExec, err := p.session("output")
 	if err != nil {
-		return false, "", fmt.Errorf("failed to create plugin executor: %w", err)
+		return false, "", err
 	}
-	defer pluginExec.Close()
 
 	// Execute pre-execute hook.
 	return pluginExec.PreExecute(ctx)
@@ -683,12 +742,10 @@ func (p *ExternalOutputPlugin) GetFlagHelp() []input.FlagHelp {
 // into pluginExec.PostExecute and the parameter becomes load-bearing
 // without changing this signature.
 func (p *ExternalOutputPlugin) PostExecute(ctx context.Context, _ output.ExecutionContext, writtenFiles []string) error {
-	// Create executor (detects protocol automatically).
-	pluginExec, err := executor.NewWithVerbose(p.path, p.verbose)
+	pluginExec, err := p.session("output")
 	if err != nil {
-		return fmt.Errorf("failed to create plugin executor: %w", err)
+		return err
 	}
-	defer pluginExec.Close()
 
 	// Execute post-execute hook.
 	return pluginExec.PostExecute(ctx, writtenFiles)

--- a/pkg/plugin/rpc.go
+++ b/pkg/plugin/rpc.go
@@ -121,6 +121,20 @@ func (s *InputPluginRPCServer) Validate(args map[string]any, resp *string) error
 }
 
 // WallpaperPath implements the RPC method for fetching wallpaper path.
+// Configure implements the optional Configurable RPC method for input
+// plugins. See OutputPluginRPCServer.Configure.
+func (s *InputPluginRPCServer) Configure(req ConfigureRequest, resp *string) error {
+	c, ok := s.Impl.(Configurable)
+	if !ok {
+		*resp = ""
+		return nil
+	}
+	if err := c.Configure(req); err != nil {
+		*resp = err.Error()
+	}
+	return nil
+}
+
 func (s *InputPluginRPCServer) WallpaperPath(_ any, resp *string) error {
 	*resp = s.Impl.WallpaperPath()
 	return nil
@@ -241,6 +255,22 @@ func (c *InputPluginRPCClient) GetMetadata() (PluginInfo, error) {
 // against pre-0.3.0 SDKs don't expose the method — net/rpc surfaces
 // that as "can't find method", which is mapped to a successful
 // validation so older plugins remain compatible.
+// Configure calls the remote optional Configure method for input
+// plugins. See OutputPluginRPCClient.Configure.
+func (c *InputPluginRPCClient) Configure(req ConfigureRequest) error {
+	var msg string
+	if err := call(c.client, "Plugin.Configure", req, &msg, callTimeout); err != nil {
+		if isMissingMethodErr(err) {
+			return nil
+		}
+		return fmt.Errorf("RPC call failed: %w", err)
+	}
+	if msg != "" {
+		return &RPCError{Message: msg}
+	}
+	return nil
+}
+
 func (c *InputPluginRPCClient) Validate(args map[string]any) error {
 	if args == nil {
 		args = map[string]any{}
@@ -370,6 +400,21 @@ func (s *OutputPluginRPCServer) Validate(args map[string]any, resp *string) erro
 	return nil
 }
 
+// Configure implements the optional Configurable RPC method. Plugins
+// that do not implement Configurable simply succeed with no effect, so
+// the host never has to distinguish "unsupported" from "no-op".
+func (s *OutputPluginRPCServer) Configure(req ConfigureRequest, resp *string) error {
+	c, ok := s.Impl.(Configurable)
+	if !ok {
+		*resp = ""
+		return nil
+	}
+	if err := c.Configure(req); err != nil {
+		*resp = err.Error()
+	}
+	return nil
+}
+
 // GetHooks implements the optional HooksProvider RPC method. Returns
 // the gob-safe subset of the plugin's hooks.Spec; function fields
 // (ReloadFn, InstructionsFn, Wallpaper) are not transmitted because
@@ -472,6 +517,25 @@ func (c *OutputPluginRPCClient) Validate(args map[string]any) error {
 	var msg string
 	err := call(c.client, "Plugin.Validate", args, &msg, callTimeout)
 	if err != nil {
+		if isMissingMethodErr(err) {
+			return nil
+		}
+		return fmt.Errorf("RPC call failed: %w", err)
+	}
+	if msg != "" {
+		return &RPCError{Message: msg}
+	}
+	return nil
+}
+
+// Configure calls the remote optional Configure method, handing the
+// plugin its args before the pre-execute lifecycle begins. A plugin
+// built against a pre-0.3.0 SDK has no such method; net/rpc reports
+// that as "can't find method" and we treat it as a no-op rather than an
+// error, matching Validate and GetHooks.
+func (c *OutputPluginRPCClient) Configure(req ConfigureRequest) error {
+	var msg string
+	if err := call(c.client, "Plugin.Configure", req, &msg, callTimeout); err != nil {
 		if isMissingMethodErr(err) {
 			return nil
 		}

--- a/pkg/plugin/rpc_test.go
+++ b/pkg/plugin/rpc_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"image/color"
 	"net"
 	"net/rpc"
@@ -379,6 +380,76 @@ func TestFlagHelp(t *testing.T) {
 		t.Error("Required = false, want true")
 	}
 }
+
+// --- Configure -------------------------------------------------------------
+
+type configurableOutput struct {
+	OutputPlugin
+	got   ConfigureRequest
+	calls int
+	err   error
+}
+
+func (c *configurableOutput) Configure(req ConfigureRequest) error {
+	c.got = req
+	c.calls++
+	return c.err
+}
+
+// A plugin implementing Configurable receives the host's args.
+func TestOutputRPCServerConfigure(t *testing.T) {
+	impl := &configurableOutput{}
+	srv := &OutputPluginRPCServer{Impl: impl}
+
+	var resp string
+	req := ConfigureRequest{Args: map[string]any{"output-dir": "/tmp/x"}, DryRun: true, Verbose: true}
+	if err := srv.Configure(req, &resp); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+	if resp != "" {
+		t.Errorf("resp = %q, want empty", resp)
+	}
+	if impl.calls != 1 {
+		t.Fatalf("Configure called %d times, want 1", impl.calls)
+	}
+	if got := impl.got.Args["output-dir"]; got != "/tmp/x" {
+		t.Errorf("Args[output-dir] = %v, want /tmp/x", got)
+	}
+	if !impl.got.DryRun || !impl.got.Verbose {
+		t.Errorf("DryRun/Verbose not propagated: %+v", impl.got)
+	}
+}
+
+// A plugin error is reported in the response rather than as a transport
+// error, so the host can decide it is non-fatal.
+func TestOutputRPCServerConfigureReportsPluginError(t *testing.T) {
+	impl := &configurableOutput{err: errors.New("bad output dir")}
+	srv := &OutputPluginRPCServer{Impl: impl}
+
+	var resp string
+	if err := srv.Configure(ConfigureRequest{}, &resp); err != nil {
+		t.Fatalf("Configure returned transport error: %v", err)
+	}
+	if resp != "bad output dir" {
+		t.Errorf("resp = %q, want the plugin's error text", resp)
+	}
+}
+
+// Plugins that predate Configurable must not break: the server treats
+// them as a successful no-op.
+func TestOutputRPCServerConfigureNonConfigurableIsNoOp(t *testing.T) {
+	srv := &OutputPluginRPCServer{Impl: &nonConfigurableOutput{}}
+
+	var resp string
+	if err := srv.Configure(ConfigureRequest{Args: map[string]any{"a": 1}}, &resp); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+	if resp != "" {
+		t.Errorf("resp = %q, want empty", resp)
+	}
+}
+
+type nonConfigurableOutput struct{ OutputPlugin }
 
 // --- bounded RPC -----------------------------------------------------------
 

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -50,6 +50,32 @@ func HookSpecToSpec(p HookSpecPayload) hooks.Spec {
 	}
 }
 
+// ConfigureRequest carries the host's per-run configuration to a plugin
+// before any other lifecycle call.
+//
+// Args, DryRun and Verbose also travel inside PaletteData on Generate;
+// this delivers them earlier, so a plugin's PreExecute and Hooks can act
+// on flags such as an overridden output directory instead of having to
+// assume defaults. It exists because those two RPCs carry no arguments
+// of their own and, historically, ran in a throwaway process that could
+// not have learned anything anyway.
+type ConfigureRequest struct {
+	Args    map[string]any
+	DryRun  bool
+	Verbose bool
+}
+
+// Configurable is an optional interface plugins may implement to receive
+// the host's per-run configuration before PreExecute / Hooks / Generate.
+//
+// Implementations should only record the values; the host treats a
+// Configure error as non-fatal and continues the run. Plugins that do
+// not implement it keep working unchanged — they simply see their args
+// for the first time in Generate, as before.
+type Configurable interface {
+	Configure(req ConfigureRequest) error
+}
+
 // InputOptions holds options for input plugin generation.
 type InputOptions struct {
 	Verbose         bool           `json:"verbose"`


### PR DESCRIPTION
Every external-plugin RPC created its own executor and killed it — `Validate`, `GetHooks`, `PreExecute`, `Generate`, `PostExecute`, each `executor.NewWithVerbose(...)` + `defer Close()`. Seven such call sites in `manager.go`.

Measured on a single `-o noctalia` run:

| | before | after |
|---|---|---|
| noctalia spawns | 5 | **1** |
| plugin spawns, full generate | ~25 | **3** |
| `yamux: Failed to write header` per run | ~1 | 0, 1, 0 over three runs |

Five handshakes, five yamux sessions and five kills for one output file. The churn is also what produced the stray yamux lines: go-plugin's graceful shutdown calls `Control.Quit` (the child exits) and *then* closes the yamux streams, so every teardown races the child's exit. Fewer teardowns, fewer races. (Eliminating them entirely needs an upstream change — go-plugin hardcodes `yamux.Client(conn, nil)`, so `DefaultConfig().LogOutput = os.Stderr` bypasses the hclog logger it already holds.)

## The deeper problem

Each spawn got a fresh plugin object, so anything a plugin learned in one call was gone by the next. Args only ever travelled inside `PaletteData` on `Generate` — which runs *after* `PreExecute` and `Hooks`. Those two RPCs carry no arguments of their own and ran in a throwaway process that could not have retained them anyway.

So this adds an optional `Configurable` interface and `Plugin.Configure` RPC, pushing args/dry-run/verbose in once when the session connects. It follows the existing optional-RPC convention exactly: unknown-method errors go through `isMissingMethodErr` and are treated as a no-op, so pre-0.3.0 plugins are unaffected, and a `Configure` failure is non-fatal — the plugin still generates, it just sees args later as before.

## `--noctalia.output-dir` finally does something

It was accepted and silently ignored. `p.outputDir` was never assigned and `Generate` never read `PaletteData.PluginArgs`, so the flag was inert and the README documented behaviour that did not exist:

```
$ tinct generate … -o noctalia --noctalia.output-dir /tmp/od
   /home/johnm/.config/noctalia/palettes/tinct.json   ← default path
$ ls /tmp/od → empty
```

Now it writes where asked, expands `~` (the host passes args as literal strings), and suppresses the config-directory check when set — which is how you generate for a machine that has no Noctalia install of its own.

## Verbose capture for external input plugins

A consequence worth calling out: the go-plugin logger is fixed when the subprocess starts, so verbose has to be set before the first RPC. With a cached session, `Validate` runs first — and for input plugins the CLI never set verbose at all, so `-i <external> --verbose` silently lost its debug output. `verbose` moves onto `externalPluginBase` with a shared setter, and the CLI sets it before `Validate`.

## Tests

`Configure` server behaviour: propagation of args/dry-run/verbose, a plugin error reported in the response rather than as a transport error, and a non-configurable plugin treated as a successful no-op. Plus noctalia's arg handling — absolute path, `~` expansion, empty value, wrong type, absent key — the `Hooks` bypass, and `Generate` writing to the configured directory.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV