### PR TITLE
feat(hooks): add any-of detection groups and message formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 ### Added
 
+- `hooks.Spec.RequiredAny` — a satisfied-by-any detection group (`AnyOf{Binaries, Dirs, Reason}`). Groups are ANDed, entries within a group ORed, so plugins whose app has more than one valid install shape no longer need a hand-rolled `PreExecute`. Paths are checked with `os.Stat`, so plain files (`kdeglobals`, `config.toml`) count as markers; binaries still resolve through appdetect (PATH/Flatpak/AppImage). An optional per-group `Reason` replaces the generated skip message.
+- Multi-line skip reasons and `Instructions` are formatted by the hook runner. `hooks.Indent` dedents continuation lines and re-indents them under the header, preserving relative nesting so a command indented under a numbered step stays indented.
 - Optional `Configurable` plugin interface and `Plugin.Configure` RPC. The host pushes args, dry-run and verbose into a plugin before the pre-execute lifecycle, so `PreExecute` and `Hooks` can honour flags instead of assuming defaults. Plugins that do not implement it are unaffected — unknown-method errors fall back like `Validate` and `GetHooks`.
 
 ### Changed
 
+- kde-plasma, rosec, qt5, qt6 and spicetify move their installation detection (and, for spicetify, the manual-apply message) off hand-rolled `PreExecute`/`PostExecute` onto the declarative `hooks.Spec`.
 - External plugins keep one subprocess for a whole run instead of spawning a fresh one per RPC. A full generate went from ~25 plugin launches to 3 (5 to 1 for a single-plugin run), which also all but removes the stray `yamux: Failed to write header` lines those teardowns produced.
 
 ### Fixed

--- a/contrib/plugins/output/spicetify/plugin.go
+++ b/contrib/plugins/output/spicetify/plugin.go
@@ -6,12 +6,12 @@ import (
 	"embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"text/template"
 
 	"github.com/jmylchreest/tinct/pkg/colour"
 	tinctplugin "github.com/jmylchreest/tinct/pkg/plugin"
+	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 	tincttemplate "github.com/jmylchreest/tinct/pkg/template"
 )
 
@@ -105,41 +105,40 @@ func (p *Plugin) loadTemplate(verbose bool) (*template.Template, error) {
 	return tmpl, nil
 }
 
-// PreExecute verifies that the spicetify CLI is installed.
-//
-// Without spicetify, the theme files we'd write are useless — there's no
-// way to apply them. Skip with a clear pointer to the install docs.
+// PreExecute and PostExecute are no-ops — both the install check and the
+// manual apply instructions are declared in Hooks().
 func (p *Plugin) PreExecute(_ context.Context) (skip bool, reason string, err error) {
-	if _, lookErr := exec.LookPath("spicetify"); lookErr != nil {
-		return true, "spicetify CLI not installed; install from https://spicetify.app", nil
-	}
 	return false, "", nil
 }
 
-// PostExecute prints the manual apply instructions when verbose.
+func (p *Plugin) PostExecute(_ context.Context, _ []string) error {
+	return nil
+}
+
+// Hooks declares spicetify's install check and its apply instructions.
 //
-// We intentionally do NOT auto-run `spicetify apply`:
+// We intentionally do NOT auto-run `spicetify apply`, so there is no
+// reload verb here:
 //   - apply patches Spotify's installed app directory (invasive).
 //   - it requires the Spotify client to be closed; running it under a
 //     live Spotify produces a partially-patched client.
 //   - it can fail in user-visible ways that the user needs to see (e.g.
 //     permission errors on the Spotify dir on first run).
 //
-// The user is the right actor to choose when to do this.
-func (p *Plugin) PostExecute(_ context.Context, files []string) error {
-	if len(files) == 0 {
-		return nil
+// The user is the right actor to choose when to do this. The runner
+// prints Instructions only in verbose mode and only when files were
+// written, and re-indents the continuation lines.
+//
+// Implements tinctplugin.HooksProvider (protocol 0.3.0+).
+func (p *Plugin) Hooks() hooks.Spec {
+	return hooks.Spec{
+		RequiredBinaries: []string{"spicetify"},
+		Instructions: "theme written but NOT applied. To activate:\n" +
+			"  1. Close Spotify completely.\n" +
+			"  2. Run:\n" +
+			"       spicetify config current_theme tinct color_scheme tinct\n" +
+			"       spicetify apply",
 	}
-
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "   spicetify: theme written but NOT applied. To activate:")
-	fmt.Fprintln(os.Stderr, "     1. Close Spotify completely.")
-	fmt.Fprintln(os.Stderr, "     2. Run:")
-	fmt.Fprintln(os.Stderr, "          spicetify config current_theme tinct color_scheme tinct")
-	fmt.Fprintln(os.Stderr, "          spicetify apply")
-	fmt.Fprintln(os.Stderr, "")
-
-	return nil
 }
 
 // stdLogger implements the Logger interface for template loading.

--- a/internal/cli/generate_helpers.go
+++ b/internal/cli/generate_helpers.go
@@ -454,6 +454,12 @@ func preparePluginExecutions(ctx context.Context, plugins []output.Plugin) []plu
 	return executions
 }
 
+// skipReasonIndent is the continuation indent for multi-line skip
+// reasons. Plugins can return install hints spanning several lines; the
+// runner's Indent helper re-aligns everything after the first line to
+// this column so a 30-plugin run stays scannable.
+const skipReasonIndent = "   "
+
 // shouldSkipFromPreHook runs the pre-execute checks and determines if a
 // plugin should be skipped. It evaluates the declarative hooks.Spec first
 // (if the plugin implements hooks.Provider), then the optional imperative
@@ -475,7 +481,7 @@ func shouldSkipFromPreHook(ctx context.Context, plugin output.Plugin, exec *plug
 		}
 		if skip {
 			if generateVerbose {
-				fmt.Fprintf(os.Stderr, "⊘ Skipping %s: %s\n", plugin.Name(), reason)
+				fmt.Fprintf(os.Stderr, "⊘ Skipping %s: %s\n", plugin.Name(), hooks.Indent(reason, skipReasonIndent))
 			}
 			exec.skip = true
 			exec.skipReason = reason
@@ -501,7 +507,7 @@ func shouldSkipFromPreHook(ctx context.Context, plugin output.Plugin, exec *plug
 
 	if skip {
 		if generateVerbose {
-			fmt.Fprintf(os.Stderr, "⊘ Skipping %s: %s\n", plugin.Name(), reason)
+			fmt.Fprintf(os.Stderr, "⊘ Skipping %s: %s\n", plugin.Name(), hooks.Indent(reason, skipReasonIndent))
 		}
 		exec.skip = true
 		exec.skipReason = reason

--- a/internal/plugin/output/kde-plasma/kde-plasma.go
+++ b/internal/plugin/output/kde-plasma/kde-plasma.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jmylchreest/tinct/internal/pluginconfig"
 	"github.com/jmylchreest/tinct/internal/version"
 	"github.com/jmylchreest/tinct/pkg/dbus"
+	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 	"github.com/jmylchreest/tinct/pkg/plugin/paths"
 )
 
@@ -99,32 +100,27 @@ func (p *Plugin) DefaultOutputDir() string {
 		filepath.Join(paths.XDGDataDir(), "color-schemes"))
 }
 
-// PreExecute checks if KDE Plasma is installed.
+// PreExecute is a no-op — detection is declared in Hooks().
 func (p *Plugin) PreExecute(_ context.Context) (skip bool, reason string, err error) {
-	// Check if KDE config directory exists
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return true, "Could not determine home directory", nil
-	}
-
-	kdeConfigDir := filepath.Join(home, ".config", "kdeglobals")
-	plasmarcPath := filepath.Join(home, ".config", "plasmarc")
-
-	// Check for either kdeglobals or plasmarc to determine if KDE is installed
-	_, kdeErr := os.Stat(kdeConfigDir)
-	_, plasmaErr := os.Stat(plasmarcPath)
-
-	if os.IsNotExist(kdeErr) && os.IsNotExist(plasmaErr) {
-		return true, fmt.Sprintf(
-			"KDE Plasma does not appear to be installed.\n"+
-				"  Neither %s nor %s exist.\n"+
-				"  This plugin is for KDE Plasma desktop environment.\n"+
-				"  For Qt apps on other desktops, use the qt5 or qt6 plugins instead.",
-			kdeConfigDir, plasmarcPath,
-		), nil
-	}
-
 	return false, "", nil
+}
+
+// Hooks declares KDE Plasma's detection. Either marker file is enough,
+// so this is an any-of group; RequiredDirs would demand both. The
+// entries are files rather than directories, which AnyOf accepts.
+func (p *Plugin) Hooks() hooks.Spec {
+	kdeglobals := filepath.Join(paths.XDGConfigDir(), "kdeglobals")
+	plasmarc := filepath.Join(paths.XDGConfigDir(), "plasmarc")
+	return hooks.Spec{
+		RequiredAny: []hooks.AnyOf{{
+			Dirs: []string{kdeglobals, plasmarc},
+			Reason: fmt.Sprintf("KDE Plasma does not appear to be installed.\n"+
+				"Neither %s nor %s exist.\n"+
+				"This plugin is for the KDE Plasma desktop environment.\n"+
+				"For Qt apps on other desktops, use the qt5 or qt6 plugins instead.",
+				kdeglobals, plasmarc),
+		}},
+	}
 }
 
 // Generate creates the KDE Plasma color scheme files.

--- a/internal/plugin/output/qt5/qt5.go
+++ b/internal/plugin/output/qt5/qt5.go
@@ -19,8 +19,8 @@ import (
 	tmplloader "github.com/jmylchreest/tinct/internal/plugin/output/template"
 	"github.com/jmylchreest/tinct/internal/pluginconfig"
 	"github.com/jmylchreest/tinct/internal/version"
+	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 	"github.com/jmylchreest/tinct/pkg/plugin/paths"
-	"github.com/jmylchreest/tinct/pkg/util/appdetect"
 )
 
 //go:embed *.tmpl
@@ -92,23 +92,26 @@ func (p *Plugin) DefaultOutputDir() string {
 		filepath.Join(paths.XDGConfigDir(), "qt5ct", "colors"))
 }
 
-// PreExecute checks if the qt5ct config directory exists.
+// PreExecute is a no-op — detection is declared in Hooks().
 func (p *Plugin) PreExecute(_ context.Context) (skip bool, reason string, err error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return true, "cannot determine home directory", nil
-	}
-
-	qt5ctConfigDir := filepath.Join(home, ".config", "qt5ct")
-
-	// Check if qt5ct config directory exists
-	if !appdetect.IsPresentAll(nil, []string{qt5ctConfigDir}) {
-		return true, fmt.Sprintf("qt5ct config directory does not exist (%s). Install qt5ct first:\n"+
-			"  Arch/CachyOS: sudo pacman -S qt5ct\n"+
-			"  Then set: export QT_QPA_PLATFORMTHEME=qt5ct", qt5ctConfigDir), nil
-	}
-
 	return false, "", nil
+}
+
+// Hooks declares qt5's detection. A single-entry AnyOf group is used
+// rather than RequiredDirs so the skip carries the install hint: the
+// generic "required directory does not exist" tells a user what is
+// missing but not what to do about it.
+func (p *Plugin) Hooks() hooks.Spec {
+	qt5ctConfigDir := filepath.Join(paths.XDGConfigDir(), "qt5ct")
+	return hooks.Spec{
+		RequiredAny: []hooks.AnyOf{{
+			Dirs: []string{qt5ctConfigDir},
+			Reason: fmt.Sprintf("qt5ct config directory does not exist (%s).\n"+
+				"Install qt5ct first:\n"+
+				"Arch/CachyOS: sudo pacman -S qt5ct\n"+
+				"Then set: export QT_QPA_PLATFORMTHEME=qt5ct", qt5ctConfigDir),
+		}},
+	}
 }
 
 // Generate creates the Qt5 color scheme file.

--- a/internal/plugin/output/qt6/qt6.go
+++ b/internal/plugin/output/qt6/qt6.go
@@ -19,8 +19,8 @@ import (
 	tmplloader "github.com/jmylchreest/tinct/internal/plugin/output/template"
 	"github.com/jmylchreest/tinct/internal/pluginconfig"
 	"github.com/jmylchreest/tinct/internal/version"
+	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 	"github.com/jmylchreest/tinct/pkg/plugin/paths"
-	"github.com/jmylchreest/tinct/pkg/util/appdetect"
 )
 
 //go:embed *.tmpl
@@ -92,23 +92,26 @@ func (p *Plugin) DefaultOutputDir() string {
 		filepath.Join(paths.XDGConfigDir(), "qt6ct", "colors"))
 }
 
-// PreExecute checks if the qt6ct config directory exists.
+// PreExecute is a no-op — detection is declared in Hooks().
 func (p *Plugin) PreExecute(_ context.Context) (skip bool, reason string, err error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return true, "cannot determine home directory", nil
-	}
-
-	qt6ctConfigDir := filepath.Join(home, ".config", "qt6ct")
-
-	// Check if qt6ct config directory exists
-	if !appdetect.IsPresentAll(nil, []string{qt6ctConfigDir}) {
-		return true, fmt.Sprintf("qt6ct config directory does not exist (%s). Install qt6ct first:\n"+
-			"  Arch/CachyOS: sudo pacman -S qt6ct\n"+
-			"  Then set: export QT_QPA_PLATFORMTHEME=qt6ct", qt6ctConfigDir), nil
-	}
-
 	return false, "", nil
+}
+
+// Hooks declares qt6's detection. A single-entry AnyOf group is used
+// rather than RequiredDirs so the skip carries the install hint: the
+// generic "required directory does not exist" tells a user what is
+// missing but not what to do about it.
+func (p *Plugin) Hooks() hooks.Spec {
+	qt6ctConfigDir := filepath.Join(paths.XDGConfigDir(), "qt6ct")
+	return hooks.Spec{
+		RequiredAny: []hooks.AnyOf{{
+			Dirs: []string{qt6ctConfigDir},
+			Reason: fmt.Sprintf("qt6ct config directory does not exist (%s).\n"+
+				"Install qt6ct first:\n"+
+				"Arch/CachyOS: sudo pacman -S qt6ct\n"+
+				"Then set: export QT_QPA_PLATFORMTHEME=qt6ct", qt6ctConfigDir),
+		}},
+	}
 }
 
 // Generate creates the Qt6 color scheme file.

--- a/internal/plugin/output/rosec/rosec.go
+++ b/internal/plugin/output/rosec/rosec.go
@@ -7,7 +7,6 @@ import (
 	"embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"text/template"
 
@@ -19,6 +18,7 @@ import (
 	tmplloader "github.com/jmylchreest/tinct/internal/plugin/output/template"
 	"github.com/jmylchreest/tinct/internal/pluginconfig"
 	"github.com/jmylchreest/tinct/internal/version"
+	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 	"github.com/jmylchreest/tinct/pkg/plugin/paths"
 )
 
@@ -135,20 +135,24 @@ func (p *Plugin) generateTheme(themeData *colour.ThemeData) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// PreExecute checks if rosec is available before generating the theme.
-// Skips if neither the rosec config file nor the rosec-prompt binary exist.
+// PreExecute is a no-op — detection is declared in Hooks().
 // Implements the output.PreExecuteHook interface.
 func (p *Plugin) PreExecute(_ context.Context) (skip bool, reason string, err error) {
-	// Check if rosec config file exists.
-	configPath := filepath.Join(p.DefaultOutputDir(), "config.toml")
-	if _, err := os.Stat(configPath); err == nil {
-		return false, "", nil
-	}
+	return false, "", nil
+}
 
-	// Check if rosec-prompt binary exists on PATH.
-	if _, err := exec.LookPath("rosec-prompt"); err == nil {
-		return false, "", nil
+// Hooks declares rosec's detection. rosec counts as installed if EITHER
+// its config file exists OR the rosec-prompt binary is on PATH — an
+// any-of group, which RequiredDirs / RequiredBinaries cannot express
+// because both are all-of.
+func (p *Plugin) Hooks() hooks.Spec {
+	return hooks.Spec{
+		RequiredAny: []hooks.AnyOf{{
+			Binaries: []string{"rosec-prompt"},
+			Dirs:     []string{filepath.Join(p.DefaultOutputDir(), "config.toml")},
+			Reason: "rosec does not appear to be installed.\n" +
+				"Neither ~/.config/rosec/config.toml nor the rosec-prompt binary was found.\n" +
+				"Install rosec-prompt, or create the config, to enable this plugin.",
+		}},
 	}
-
-	return true, "neither rosec config (~/.config/rosec/config.toml) nor rosec-prompt binary found", nil
 }

--- a/pkg/plugin/hooks/hooks.go
+++ b/pkg/plugin/hooks/hooks.go
@@ -18,6 +18,7 @@ type Spec struct {
 	RequiredBinaries []string
 	OptionalBinaries []string
 	RequiredDirs     []string
+	RequiredAny      []AnyOf
 	AutoCreateDir    bool
 
 	Reload   *ReloadSpec
@@ -30,6 +31,33 @@ type Spec struct {
 
 	Instructions   string
 	InstructionsFn func(ctx Context) string
+}
+
+// AnyOf is a satisfied-by-any group of detection candidates: the group
+// passes when ANY of its Binaries or Dirs is present. Groups in
+// Spec.RequiredAny are ANDed with each other (and with RequiredBinaries
+// / RequiredDirs), so "all groups must be satisfied, each by at least
+// one of its entries".
+//
+// This is the primitive for apps with more than one valid install
+// shape — a config that may live in either of two places, or a tool
+// detectable by config file OR by binary:
+//
+//	AnyOf{Dirs: []string{"~/.config/kdeglobals", "~/.config/plasmarc"}}
+//	AnyOf{Binaries: []string{"rosec-prompt"}, Dirs: []string{"~/.config/rosec/config.toml"}}
+//
+// Binaries are resolved with appdetect (PATH, Flatpak, AppImage); Dirs
+// accept files as well as directories and are ~-expanded. A single-entry
+// group is legitimate when the point is to attach a better Reason than
+// the runner's generated one.
+//
+// Reason, when non-empty, replaces the generated skip message. It may be
+// multi-line — the runner indents continuation lines so install hints
+// stay readable in a multi-plugin run.
+type AnyOf struct {
+	Binaries []string
+	Dirs     []string
+	Reason   string
 }
 
 // ReloadSpec describes a reload action as a verb plus arguments. Bare

--- a/pkg/plugin/hooks/hooks_test.go
+++ b/pkg/plugin/hooks/hooks_test.go
@@ -225,3 +225,117 @@ func TestRenderTemplate(t *testing.T) {
 		})
 	}
 }
+
+// --- RequiredAny / Indent -------------------------------------------------
+
+func TestRunPreRequiredAny(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "present")
+	if err := os.MkdirAll(present, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "missing")
+
+	tests := []struct {
+		name     string
+		spec     Spec
+		wantSkip bool
+		wantWord string
+	}{
+		{
+			name:     "satisfied by the second candidate",
+			spec:     Spec{RequiredAny: []AnyOf{{Dirs: []string{missing, present}}}},
+			wantSkip: false,
+		},
+		{
+			name:     "no candidate present",
+			spec:     Spec{RequiredAny: []AnyOf{{Dirs: []string{missing, missing + "2"}}}},
+			wantSkip: true,
+			wantWord: "none of the following were found",
+		},
+		{
+			name:     "custom reason wins",
+			spec:     Spec{RequiredAny: []AnyOf{{Dirs: []string{missing}, Reason: "install the thing"}}},
+			wantSkip: true,
+			wantWord: "install the thing",
+		},
+		{
+			name: "groups are ANDed",
+			spec: Spec{RequiredAny: []AnyOf{
+				{Dirs: []string{present}},
+				{Dirs: []string{missing}},
+			}},
+			wantSkip: true,
+			wantWord: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skip, reason, err := RunPre(tt.spec, Context{PluginName: "test"})
+			if err != nil {
+				t.Fatalf("RunPre error: %v", err)
+			}
+			if skip != tt.wantSkip {
+				t.Fatalf("skip = %v (reason %q), want %v", skip, reason, tt.wantSkip)
+			}
+			if tt.wantWord != "" && !strings.Contains(reason, tt.wantWord) {
+				t.Errorf("reason = %q, want it to contain %q", reason, tt.wantWord)
+			}
+		})
+	}
+}
+
+// A file (not a directory) must satisfy an AnyOf group — kde-plasma
+// detects via kdeglobals/plasmarc, which are files.
+func TestRunPreRequiredAnyAcceptsFiles(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "kdeglobals")
+	if err := os.WriteFile(marker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	skip, reason, err := RunPre(Spec{RequiredAny: []AnyOf{{Dirs: []string{marker}}}}, Context{})
+	if err != nil {
+		t.Fatalf("RunPre error: %v", err)
+	}
+	if skip {
+		t.Errorf("skipped on an existing file: %s", reason)
+	}
+}
+
+func TestIndent(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{
+			name: "single line is untouched",
+			msg:  "nothing to align",
+			want: "nothing to align",
+		},
+		{
+			name: "continuation lines are re-indented",
+			msg:  "line one\nline two\nline three",
+			want: "line one\n>>line two\n>>line three",
+		},
+		{
+			name: "relative nesting survives the dedent",
+			msg:  "header:\n  1. step\n  2. run:\n       a command",
+			want: "header:\n>>1. step\n>>2. run:\n>>     a command",
+		},
+		{
+			name: "blank lines do not become trailing whitespace",
+			msg:  "header:\n\n  tail",
+			want: "header:\n\n>>tail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Indent(tt.msg, ">>"); got != tt.want {
+				t.Errorf("Indent()\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/hooks/runner.go
+++ b/pkg/plugin/hooks/runner.go
@@ -42,6 +42,13 @@ func RunPre(spec Spec, hctx Context) (skip bool, reason string, err error) {
 		}
 	}
 
+	for _, group := range spec.RequiredAny {
+		if group.satisfied() {
+			continue
+		}
+		return true, group.skipReason(), nil
+	}
+
 	if spec.AutoCreateDir && hctx.OutputDir != "" {
 		if _, statErr := os.Stat(hctx.OutputDir); os.IsNotExist(statErr) {
 			if mkErr := os.MkdirAll(hctx.OutputDir, 0o750); mkErr != nil {
@@ -54,6 +61,112 @@ func RunPre(spec Spec, hctx Context) (skip bool, reason string, err error) {
 	}
 
 	return false, "", nil
+}
+
+// satisfied reports whether any single candidate in the group is
+// present. Binaries go through appdetect (PATH, Flatpak, AppImage);
+// paths are checked with os.Stat rather than appdetect's dirExists,
+// because detection markers are frequently plain files (kdeglobals,
+// config.toml) and appdetect only counts directories.
+func (g AnyOf) satisfied() bool {
+	for _, bin := range g.Binaries {
+		if bin != "" && appdetect.IsPresentAny([]string{bin}, nil) {
+			return true
+		}
+	}
+	for _, d := range g.Dirs {
+		if d == "" {
+			continue
+		}
+		if _, err := os.Stat(expandHome(d)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// skipReason renders the message shown when an AnyOf group is not
+// satisfied: the plugin's own Reason when it set one, otherwise a
+// generated "none of ..." listing every candidate the group accepted.
+func (g AnyOf) skipReason() string {
+	if g.Reason != "" {
+		return g.Reason
+	}
+
+	candidates := make([]string, 0, len(g.Binaries)+len(g.Dirs))
+	for _, b := range g.Binaries {
+		if b != "" {
+			candidates = append(candidates, b+" (executable)")
+		}
+	}
+	for _, d := range g.Dirs {
+		if d != "" {
+			candidates = append(candidates, d)
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return "no detection candidates declared"
+	case 1:
+		return "not found: " + candidates[0]
+	default:
+		return "none of the following were found: " + strings.Join(candidates, ", ")
+	}
+}
+
+// Indent formats a possibly multi-line message for display under a
+// "⊘ Skipping <plugin>: " or "   <plugin>: " style header.
+//
+// The first line is returned as-is — it follows the header on the same
+// line. Continuation lines are dedented by their common leading
+// whitespace and then re-indented to `indent`, so a message written as
+// a naturally-indented Go string literal lands aligned under the header
+// while keeping its *relative* structure: a command nested under a
+// numbered step stays nested. Blank lines stay blank rather than
+// becoming trailing whitespace.
+//
+// Exported because the CLI formats skip reasons at its own indent level
+// and should not reimplement this.
+func Indent(msg, indent string) string {
+	lines := strings.Split(msg, "\n")
+	if len(lines) == 1 {
+		return msg
+	}
+
+	common := commonIndent(lines[1:])
+
+	out := make([]string, 0, len(lines))
+	out = append(out, strings.TrimRight(lines[0], " \t"))
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "" {
+			out = append(out, "")
+			continue
+		}
+		out = append(out, indent+strings.TrimRight(strings.TrimPrefix(line, common), " \t"))
+	}
+	return strings.Join(out, "\n")
+}
+
+// commonIndent returns the longest leading run of spaces/tabs shared by
+// every non-blank line, which Indent strips before re-indenting.
+func commonIndent(lines []string) string {
+	common := ""
+	first := true
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lead := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+		if first {
+			common, first = lead, false
+			continue
+		}
+		for !strings.HasPrefix(lead, common) {
+			common = common[:len(common)-1]
+		}
+	}
+	return common
 }
 
 // linePrefix returns the verbose-output prefix for a plugin. When name is
@@ -137,6 +250,12 @@ func applyMakeExecutable(names, written []string, pluginName string, verbose boo
 	}
 }
 
+// instructionIndent is the hanging indent for continuation lines of a
+// multi-line Instructions block, sized to sit clear of the "   " that
+// prefixes every tinct output line without tracking the plugin-name
+// width (which varies per plugin).
+const instructionIndent = "     "
+
 func printInstructions(spec Spec, hctx Context) {
 	var msg string
 	switch {
@@ -145,9 +264,17 @@ func printInstructions(spec Spec, hctx Context) {
 	case spec.Instructions != "":
 		msg = renderTemplate(spec.Instructions, hctx)
 	}
-	if msg != "" {
-		fmt.Fprintln(os.Stderr, msg)
+	if msg == "" {
+		return
 	}
+
+	// Instructions have no header line of their own, so the plugin
+	// prefix is added here and continuation lines get a hanging indent
+	// rather than repeating "<plugin>: " on every row. TrimLeft keeps
+	// older single-line Instructions — which embed their own leading
+	// indent — from being double-indented.
+	prefix := linePrefix(hctx.PluginName)
+	fmt.Fprintln(os.Stderr, prefix+Indent(strings.TrimLeft(msg, " \t"), instructionIndent))
 }
 
 // renderTemplate runs the Instructions string through text/template with a

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -12,6 +12,7 @@ type HookSpecPayload struct {
 	RequiredBinaries  []string
 	OptionalBinaries  []string
 	RequiredDirs      []string
+	RequiredAny       []hooks.AnyOf
 	AutoCreateDir     bool
 	Reload            *hooks.ReloadSpec
 	MakeExecutable    []string
@@ -26,6 +27,7 @@ func HookSpecFromSpec(s hooks.Spec) HookSpecPayload {
 		RequiredBinaries:  s.RequiredBinaries,
 		OptionalBinaries:  s.OptionalBinaries,
 		RequiredDirs:      s.RequiredDirs,
+		RequiredAny:       s.RequiredAny,
 		AutoCreateDir:     s.AutoCreateDir,
 		Reload:            s.Reload,
 		MakeExecutable:    s.MakeExecutable,
@@ -42,6 +44,7 @@ func HookSpecToSpec(p HookSpecPayload) hooks.Spec {
 		RequiredBinaries:  p.RequiredBinaries,
 		OptionalBinaries:  p.OptionalBinaries,
 		RequiredDirs:      p.RequiredDirs,
+		RequiredAny:       p.RequiredAny,
 		AutoCreateDir:     p.AutoCreateDir,
 		Reload:            p.Reload,
 		MakeExecutable:    p.MakeExecutable,


### PR DESCRIPTION
`hooks.Spec` could express "all of these binaries" and "all of these directories", but not "any one of these". Plugins whose app has more than one valid install shape therefore kept hand-rolled `PreExecute` methods the declarative runner could not see:

- **kde-plasma** — `kdeglobals` **or** `plasmarc`
- **rosec** — `~/.config/rosec/config.toml` **or** the `rosec-prompt` binary (mixed dir/binary any-of)

## `RequiredAny`

```go
type AnyOf struct {
	Binaries []string   // resolved via appdetect: PATH, Flatpak, AppImage
	Dirs     []string   // os.Stat + ~ expansion — files count too
	Reason   string     // optional; replaces the generated message, may be multi-line
}
```

Groups are ANDed with each other and with `RequiredBinaries`/`RequiredDirs`; entries within a group are ORed.

Paths are checked with `os.Stat` rather than appdetect. A test caught this during development: `appdetect.dirExists` requires `IsDir()`, so `kdeglobals` and `config.toml` would silently never have matched. Binaries still go through appdetect, so Flatpak and AppImage detection is unaffected.

The optional per-group `Reason` is what makes the migration lossless for qt5/qt6, whose skip text carries install hints the runner's generic `required directory does not exist` cannot.

## Multi-line messages

Previously a plugin's embedded newlines wrapped ragged against the left margin:

```
⊘ Skipping kde-plasma: KDE Plasma does not appear to be installed.
  Neither
/home/johnm/.config/kdeglobals nor
/home/johnm/.config/plasmarc exist.
```

`hooks.Indent` dedents continuation lines and re-indents them under the header, preserving *relative* structure:

```
⊘ Skipping qt5: qt5ct config directory does not exist (/home/johnm/.config/qt5ct).
   Install qt5ct first:
   Arch/CachyOS: sudo pacman -S qt5ct
   Then set: export QT_QPA_PLATFORMTHEME=qt5ct
⊘ Skipping kde-plasma: KDE Plasma does not appear to be installed.
   Neither /home/johnm/.config/kdeglobals nor /home/johnm/.config/plasmarc exist.
   This plugin is for the KDE Plasma desktop environment.
   For Qt apps on other desktops, use the qt5 or qt6 plugins instead.
```

`Instructions` get the same treatment, plus the plugin name on the head line and a hanging indent rather than repeating `<plugin>: ` on every row — so a command nested under a numbered step stays nested:

```
   spicetify: theme written but NOT applied. To activate:
     1. Close Spotify completely.
     2. Run:
          spicetify config current_theme tinct color_scheme tinct
          spicetify apply
   ptyxis: Ptyxis watches its palette dir and picks up new palettes live. Select it in: …
```

`TrimLeft` on the head line keeps existing single-line `Instructions` (ptyxis, awob embed their own `"   "`) from double-indenting.

## Migrations

kde-plasma, rosec, qt5, qt6 and spicetify move onto the spec; their `PreExecute`/`PostExecute` bodies are now empty.

Not migrated, deliberately: opencode and zed resolve a *list* of candidate config dirs that also feeds `Generate`; gnome-shell probes extension state at runtime; qt5/qt6/kde-plasma reload over D-Bus, for which there is no verb.

## Tests

`RequiredAny` — satisfied by a later candidate, none present, custom reason wins, groups ANDed, and a plain file accepted as a marker. `Indent` — single line untouched, continuation lines re-indented, relative nesting preserved, blank lines not turned into trailing whitespace.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV