### PR TITLE
perf(noctalia): skip the reload when the palette is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 - kde-plasma, rosec, qt5, qt6 and spicetify move their installation detection (and, for spicetify, the manual-apply message) off hand-rolled `PreExecute`/`PostExecute` onto the declarative `hooks.Spec`.
 - External plugins keep one subprocess for a whole run instead of spawning a fresh one per RPC. A full generate went from ~25 plugin launches to 3 (5 to 1 for a single-plugin run), which also all but removes the stray `yamux: Failed to write header` lines those teardowns produced.
 
+### Changed
+
+- The noctalia plugin skips the shell reload when the regenerated palette is byte-identical to the one already on disk. A reload makes Noctalia re-read its whole config tree, which is wasted work when the colours have not moved — regenerating from the same wallpaper now costs nothing.
+
 ### Fixed
 
 - `--noctalia.output-dir` was accepted and silently ignored — the plugin never read `PaletteData.PluginArgs` and its output directory was never assigned. It now arrives via `Configure` before `Hooks`/`PreExecute`, expands `~`, and suppresses the config-directory check when set.

--- a/contrib/plugins/output/noctalia/README.md
+++ b/contrib/plugins/output/noctalia/README.md
@@ -9,7 +9,7 @@ plugin:
   source: external
   app: Noctalia
   app_url: https://github.com/noctalia-dev/noctalia-shell
-  version: 0.3.0
+  version: 0.4.0
   protocol_version: 0.3.0
   repository: https://github.com/jmylchreest/tinct
   install: tinct plugins install noctalia
@@ -104,7 +104,9 @@ noctalia msg config-reload
 
 That forces a config reload, which re-runs Noctalia's theme resolution and — with `source = "custom"` — re-reads `tinct.json` from disk. No user action required.
 
-The reload is declared as a `hooks.Spec` reload verb, so tinct's shared hook runner owns it: `noctalia` is an **optional** binary (the plugin detects Noctalia by config directory, not by binary, so you can still generate into a config tree for another machine), the command runs under a timeout, and a missing binary or a shell that isn't running is a non-fatal no-op.
+**The reload is skipped when the palette did not change.** Generate compares the rendered palette against the file already on disk; if they are byte-identical the shell is left alone, because a reload makes Noctalia re-read its whole config tree. Regenerating from the same wallpaper therefore costs nothing.
+
+`noctalia` is an **optional** binary — the plugin detects Noctalia by config directory, not by binary, so you can still generate into a config tree for another machine. A missing binary, or a shell that isn't running, is a non-fatal no-op, and the call runs under a timeout.
 
 **Why a reload is needed at all:** Noctalia does *not* watch the palette file. It inotifies `~/.config/noctalia` non-recursively and only treats a changed `*.toml` as a config change — `palettes/tinct.json` misses on both counts (subdirectory, and not TOML). Without the nudge the file is rewritten and the running shell keeps the colours it resolved at startup.
 

--- a/contrib/plugins/output/noctalia/main.go
+++ b/contrib/plugins/output/noctalia/main.go
@@ -13,7 +13,7 @@ import (
 var (
 	// Version is the semantic version of the plugin.
 	// Injected at build time via: -ldflags "-X main.Version=x.y.z"
-	Version = "0.3.0"
+	Version = "0.4.0"
 
 	// Commit is the git commit hash of the build.
 	// Injected at build time via: -ldflags "-X main.Commit=$(git rev-parse HEAD)"

--- a/contrib/plugins/output/noctalia/plugin.go
+++ b/contrib/plugins/output/noctalia/plugin.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/jmylchreest/tinct/pkg/colour"
 	tinctplugin "github.com/jmylchreest/tinct/pkg/plugin"
@@ -25,6 +27,16 @@ var templatesFS embed.FS
 // <paletteName>.json and selected in config via `custom_palette = "tinct"`.
 const paletteName = "tinct"
 
+// noctaliaBinary is the Noctalia CLI, used to nudge a running shell into
+// re-reading the palette.
+const noctaliaBinary = "noctalia"
+
+// reloadCommand is the command PostExecute runs. GetMetadata advertises
+// the same thing, so both derive from here rather than drifting apart.
+func reloadCommand() []string {
+	return []string{noctaliaBinary, "msg", "config-reload"}
+}
+
 // Plugin implements the tinct OutputPlugin interface for the Noctalia shell.
 //
 // Noctalia (v5) ships its own Material You generator, but reads a fixed
@@ -37,6 +49,18 @@ type Plugin struct {
 	commit    string
 	date      string
 	outputDir string
+
+	// paletteUnchanged records that Generate rendered a palette byte-
+	// identical to the one already on disk, so PostExecute can skip the
+	// reload. Reloading Noctalia re-reads its whole config tree, which is
+	// wasted work when nothing about the colours moved.
+	//
+	// The zero value deliberately means "reload". Generate and
+	// PostExecute only share this field when the host keeps one plugin
+	// subprocess for the run; against an older host they run in separate
+	// processes, the flag stays false, and the reload happens
+	// unconditionally as it did before.
+	paletteUnchanged bool
 }
 
 // noctaliaConfigDir resolves Noctalia's config directory, honouring
@@ -172,10 +196,30 @@ func (p *Plugin) Generate(_ context.Context, palette tinctplugin.PaletteData) (m
 		return nil, fmt.Errorf("failed to create palettes directory %q: %w", outputDir, err)
 	}
 
+	palettePath := filepath.Join(outputDir, paletteName+".json")
+	p.paletteUnchanged = matchesFileOnDisk(palettePath, content)
+	if p.paletteUnchanged && palette.Verbose {
+		fmt.Fprintf(os.Stderr, "   Palette unchanged; will skip the reload\n")
+	}
+
 	files := map[string][]byte{
-		filepath.Join(outputDir, paletteName+".json"): content,
+		palettePath: content,
 	}
 	return files, nil
+}
+
+// matchesFileOnDisk reports whether path already holds exactly content.
+//
+// Called from Generate, before the host writes the file, so the value on
+// disk is still the previous run's. Any uncertainty — missing file, read
+// error — answers false, because a spurious reload is cheap and a missed
+// one leaves the shell showing stale colours.
+func matchesFileOnDisk(path string, content []byte) bool {
+	existing, err := os.ReadFile(path) // #nosec G304 -- path is the plugin's own output file
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(existing, content)
 }
 
 // loadTemplate loads and parses the palette variant template.
@@ -225,49 +269,65 @@ func (p *Plugin) PreExecute(_ context.Context) (skip bool, reason string, err er
 	return false, "", nil
 }
 
-// PostExecute is a no-op — the reload is declared statically in Hooks()
-// so the host's shared runner owns the binary check and the timeout.
-func (p *Plugin) PostExecute(_ context.Context, _ []string) error {
-	return nil
-}
-
-// Hooks declares Noctalia's static post-execute behaviour.
+// PostExecute nudges the running shell to re-read the palette, unless
+// Generate found the file already byte-identical.
 //
-// Noctalia v5 does NOT pick up palette changes on its own. It inotifies
+// Noctalia v5 does not pick up palette changes on its own. It inotifies
 // ~/.config/noctalia (and ~/.local/state/noctalia) non-recursively and
 // only treats a changed *.toml as a config change. The palette misses on
 // both counts: palettes/ is a subdirectory, and tinct.json is not TOML.
-// So a regenerated palette produces no event and the running shell keeps
-// the colours it resolved at startup.
+// So a regenerated palette produces no event, and the running shell
+// keeps the colours it resolved at startup.
 //
-// `noctalia msg config-reload` forces a config reload, which re-runs the
+// `noctalia msg config-reload` forces a config reload, which re-runs
 // theme resolution and — for a custom palette source — re-reads the JSON
-// from disk. That is the whole fix, so it is the reload verb here.
+// from disk. Not `color-scheme-set custom <name>`: that re-reads the
+// file too, but persists a theme override into
+// ~/.local/state/noctalia/settings.toml which then shadows the user's
+// own config.
 //
-// The binary is optional rather than required: the plugin detects
-// Noctalia by config directory (see PreExecute), which lets users
-// generate into a config tree for a machine where the binary is absent.
-// The host runner warns about the missing binary in verbose mode and the
-// exec verb is a non-fatal no-op when it cannot be found.
+// This is imperative rather than a hooks.Spec reload verb because the
+// decision is dynamic. The declarative verb fires on every write, and
+// hooks.Spec's function fields (ReloadFn) cannot cross the RPC boundary
+// to an external plugin. The host still bounds the call —
+// runPostExecutionHooks gives PostExecute a 10s context.
 //
-// `color-scheme-set custom <name>` also re-reads the file, but persists a
-// theme override into ~/.local/state/noctalia/settings.toml that then
-// shadows the user's own config — config-reload has no such side effect.
+// Failure is deliberately silent: Noctalia may simply not be running,
+// which is not worth failing a generate over.
+func (p *Plugin) PostExecute(ctx context.Context, files []string) error {
+	if len(files) == 0 || p.paletteUnchanged {
+		return nil
+	}
+	if _, err := exec.LookPath(noctaliaBinary); err != nil {
+		return nil
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	args := reloadCommand()
+	_ = exec.CommandContext(cctx, args[0], args[1:]...).Run()
+	return nil
+}
+
+// Hooks declares Noctalia's static pre-execute behaviour: how to tell
+// whether Noctalia is installed at all.
 //
-// Detection is by config directory, declared as RequiredDirs so the
-// shared runner skips the plugin (with a consistent reason string) when
-// Noctalia is not installed. The path is resolved here rather than
-// written as a "~/.config/noctalia" literal because the runner does not
-// expand environment variables — see noctaliaConfigDir.
+// Detection is by config directory rather than by binary, so a user can
+// generate into a config tree for a machine where the CLI is absent.
+// That is why `noctalia` is an optional binary here — its absence limits
+// the reload (see PostExecute), it does not make the plugin unusable.
+//
+// The directory is resolved rather than written as a "~/.config/noctalia"
+// literal because the hook runner only expands ~, with no environment
+// variable support — see noctaliaConfigDir.
+//
+// The reload itself is not declared here: it depends on whether the
+// palette actually changed, which a static spec cannot express.
 //
 // Implements tinctplugin.HooksProvider (protocol 0.3.0+).
 func (p *Plugin) Hooks() hooks.Spec {
 	spec := hooks.Spec{
-		OptionalBinaries: []string{"noctalia"},
-		Reload: &hooks.ReloadSpec{
-			Verb: hooks.VerbExec,
-			Args: []string{"noctalia", "msg", "config-reload"},
-		},
+		OptionalBinaries: []string{noctaliaBinary},
 	}
 	// With an explicit --noctalia.output-dir the user has said where to
 	// write, so the config-directory check would be wrong — that is the
@@ -325,7 +385,7 @@ func (p *Plugin) GetMetadata() tinctplugin.PluginInfo {
 				// declarative hook in Hooks() nudges the running shell to
 				// re-resolve the palette from disk.
 				Method:             "ipc",
-				Command:            "noctalia msg config-reload",
+				Command:            strings.Join(reloadCommand(), " "),
 				UserActionRequired: false,
 			},
 		},

--- a/contrib/plugins/output/noctalia/plugin_test.go
+++ b/contrib/plugins/output/noctalia/plugin_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	tinctplugin "github.com/jmylchreest/tinct/pkg/plugin"
-	"github.com/jmylchreest/tinct/pkg/plugin/hooks"
 )
 
 var hexRe = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
@@ -183,26 +182,19 @@ func TestMetadata(t *testing.T) {
 	}
 }
 
-// TestHooksDeclaresReload guards the reload contract: Noctalia does not
-// watch its palettes directory, so a regenerated palette only takes
-// effect if the running shell is told to re-read it.
-func TestHooksDeclaresReload(t *testing.T) {
-	spec := (&Plugin{}).Hooks()
-
-	if spec.Reload == nil {
-		t.Fatal("Hooks().Reload is nil; the palette would never be reloaded")
-	}
-	if spec.Reload.Verb != hooks.VerbExec {
-		t.Errorf("Reload.Verb = %q, want %q", spec.Reload.Verb, hooks.VerbExec)
-	}
+// TestReloadCommand guards the reload contract: Noctalia does not watch
+// its palettes directory, so a regenerated palette only takes effect if
+// the running shell is told to re-read it.
+func TestReloadCommand(t *testing.T) {
 	want := []string{"noctalia", "msg", "config-reload"}
-	if !slices.Equal(spec.Reload.Args, want) {
-		t.Errorf("Reload.Args = %v, want %v", spec.Reload.Args, want)
+	if !slices.Equal(reloadCommand(), want) {
+		t.Errorf("reloadCommand() = %v, want %v", reloadCommand(), want)
 	}
 
 	// The binary guard must be optional, not required: detection is by
 	// config directory, so generating for a machine without the binary
 	// must still write the palette.
+	spec := (&Plugin{}).Hooks()
 	if !slices.Contains(spec.OptionalBinaries, "noctalia") {
 		t.Errorf("OptionalBinaries = %v, want it to contain noctalia", spec.OptionalBinaries)
 	}
@@ -264,18 +256,18 @@ func TestPreExecuteNeverSkips(t *testing.T) {
 	}
 }
 
-// TestMetadataMatchesHooks keeps the documented reload (used for README
-// frontmatter drift checks) in step with what the runner actually does.
-func TestMetadataMatchesHooks(t *testing.T) {
+// TestMetadataMatchesReload keeps the advertised reload (used for README
+// frontmatter drift checks) in step with what PostExecute actually runs.
+func TestMetadataMatchesReload(t *testing.T) {
 	p := &Plugin{}
 	meta := p.GetMetadata().Metadata
-	spec := p.Hooks()
 
-	if got, want := meta.Reload.Command, strings.Join(spec.Reload.Args, " "); got != want {
-		t.Errorf("metadata reload command = %q, hooks run %q", got, want)
+	if got, want := meta.Reload.Command, strings.Join(reloadCommand(), " "); got != want {
+		t.Errorf("metadata reload command = %q, PostExecute runs %q", got, want)
 	}
-	if !slices.Equal(meta.OptionalBinaries, spec.OptionalBinaries) {
-		t.Errorf("metadata OptionalBinaries = %v, hooks declare %v", meta.OptionalBinaries, spec.OptionalBinaries)
+	if !slices.Equal(meta.OptionalBinaries, p.Hooks().OptionalBinaries) {
+		t.Errorf("metadata OptionalBinaries = %v, hooks declare %v",
+			meta.OptionalBinaries, p.Hooks().OptionalBinaries)
 	}
 }
 
@@ -358,5 +350,106 @@ func TestGenerateHonoursConfiguredOutputDir(t *testing.T) {
 	want := filepath.Join(dir, "tinct.json")
 	if _, ok := files[want]; !ok {
 		t.Errorf("Generate wrote %v, want a file at %s", keys(files), want)
+	}
+}
+
+// --- unchanged-palette suppression ----------------------------------------
+
+// Generate must notice when the rendered palette already matches what is
+// on disk, so PostExecute can skip a pointless whole-config reload.
+func TestGenerateDetectsUnchangedPalette(t *testing.T) {
+	dir := t.TempDir()
+	p := &Plugin{}
+	if err := p.Configure(tinctplugin.ConfigureRequest{Args: map[string]any{"output-dir": dir}}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	// First run: nothing on disk yet, so the palette counts as changed.
+	files, err := p.Generate(context.Background(), testPalette("dark"))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if p.paletteUnchanged {
+		t.Error("first generate reported unchanged with no file on disk")
+	}
+
+	// Emulate the host writing what Generate returned.
+	path := filepath.Join(dir, "tinct.json")
+	if err := os.WriteFile(path, files[path], 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Second run with identical input must now report unchanged.
+	if _, err := p.Generate(context.Background(), testPalette("dark")); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !p.paletteUnchanged {
+		t.Error("second generate reported changed for a byte-identical palette")
+	}
+
+	// A different palette must flip it back.
+	if _, err := p.Generate(context.Background(), testPalette("light")); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if p.paletteUnchanged {
+		t.Error("generate reported unchanged after the colours moved")
+	}
+}
+
+func TestMatchesFileOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "palette.json")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		content []byte
+		want    bool
+	}{
+		{name: "identical", path: path, content: []byte("hello"), want: true},
+		{name: "different", path: path, content: []byte("world"), want: false},
+		{name: "trailing byte differs", path: path, content: []byte("hello\n"), want: false},
+		// Uncertainty must answer false: a spurious reload is cheap, a
+		// missed one leaves the shell showing stale colours.
+		{name: "missing file", path: filepath.Join(dir, "absent"), content: []byte("hello"), want: false},
+		{name: "unreadable directory", path: dir, content: []byte("hello"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesFileOnDisk(tt.path, tt.content); got != tt.want {
+				t.Errorf("matchesFileOnDisk = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The zero value must mean "reload". Generate and PostExecute only share
+// state when the host keeps one subprocess per run; against an older
+// host they run in separate processes and the flag is never set, so the
+// default has to be the safe one.
+func TestPaletteUnchangedDefaultsToReloading(t *testing.T) {
+	if (&Plugin{}).paletteUnchanged {
+		t.Error("zero value suppresses the reload; it must default to reloading")
+	}
+}
+
+// No files written means nothing changed on disk, so there is nothing to
+// reload for — and the host would not normally call PostExecute at all.
+func TestPostExecuteNoFilesIsNoOp(t *testing.T) {
+	if err := (&Plugin{}).PostExecute(context.Background(), nil); err != nil {
+		t.Errorf("PostExecute returned error: %v", err)
+	}
+}
+
+// Hooks no longer declares a reload verb — PostExecute owns it, because
+// the decision depends on whether the palette actually changed. Two
+// reload paths would mean two whole-config reloads per generate.
+func TestHooksDeclaresNoReloadVerb(t *testing.T) {
+	if spec := (&Plugin{}).Hooks(); spec.Reload != nil {
+		t.Errorf("Hooks declares a reload verb (%+v); PostExecute already reloads", spec.Reload)
 	}
 }

--- a/docs/docs/plugins/output/bars-launchers/noctalia.md
+++ b/docs/docs/plugins/output/bars-launchers/noctalia.md
@@ -8,7 +8,7 @@ plugin:
   source: external
   app: Noctalia
   app_url: 'https://github.com/noctalia-dev/noctalia-shell'
-  version: 0.3.0
+  version: 0.4.0
   protocol_version: 0.3.0
   repository: 'https://github.com/jmylchreest/tinct'
   install: tinct plugins install noctalia
@@ -105,7 +105,9 @@ noctalia msg config-reload
 
 That forces a config reload, which re-runs Noctalia's theme resolution and — with `source = "custom"` — re-reads `tinct.json` from disk. No user action required.
 
-The reload is declared as a `hooks.Spec` reload verb, so tinct's shared hook runner owns it: `noctalia` is an **optional** binary (the plugin detects Noctalia by config directory, not by binary, so you can still generate into a config tree for another machine), the command runs under a timeout, and a missing binary or a shell that isn't running is a non-fatal no-op.
+**The reload is skipped when the palette did not change.** Generate compares the rendered palette against the file already on disk; if they are byte-identical the shell is left alone, because a reload makes Noctalia re-read its whole config tree. Regenerating from the same wallpaper therefore costs nothing.
+
+`noctalia` is an **optional** binary — the plugin detects Noctalia by config directory, not by binary, so you can still generate into a config tree for another machine. A missing binary, or a shell that isn't running, is a non-fatal no-op, and the call runs under a timeout.
 
 **Why a reload is needed at all:** Noctalia does *not* watch the palette file. It inotifies `~/.config/noctalia` non-recursively and only treats a changed `*.toml` as a config change — `palettes/tinct.json` misses on both counts (subdirectory, and not TOML). Without the nudge the file is rewritten and the running shell keeps the colours it resolved at startup.
 


### PR DESCRIPTION
`noctalia msg config-reload` makes Noctalia re-read its **whole config tree**. That is wasted work when the colours have not moved — and they often have not, since regenerating from the same wallpaper produces a byte-identical palette.

`Generate` now compares the rendered palette against the file already on disk (it runs *before* the host writes, so what's there is still the previous run's) and records the result. `PostExecute` skips the reload when nothing changed.

```
$ tinct generate -i image -p <same wallpaper> -o noctalia --verbose
   Palette unchanged; will skip the reload
   → reloads: 0

$ tinct generate -i image -p <different wallpaper> -o noctalia
   → reloads: 1
```

## Why the reload moved out of the spec

The declarative `hooks.Spec` verb fires on **every** write — it cannot express "only if the content changed". `hooks.Spec` does have a dynamic escape hatch, `ReloadFn`, but function fields cannot cross the RPC boundary to an external plugin (they are dropped from `HookSpecPayload`). So the reload becomes imperative.

`Hooks` keeps the detection half — `RequiredDirs` plus the optional binary — and the host still bounds the call: `runPostExecutionHooks` gives `PostExecute` a 10s context. `GetMetadata` still advertises the ipc command, now derived from the same `reloadCommand()` the reload runs, so the two cannot drift.

## Two safety properties

**The zero value means "reload".** `Generate` and `PostExecute` only share state when the host keeps one subprocess per run (#14). Against an older host they are separate processes, the flag is never set, and the reload happens unconditionally exactly as before. Getting this backwards would silently break the reload on older hosts.

**Uncertainty answers "changed".** A missing file or a read error reloads. A spurious reload is cheap; a missed one leaves the shell showing stale colours.

## Context

This replaces a user-side workaround. Before the plugin reloaded at all (#13), the only fix was a global `post-generate.sh` — which fires on every generate regardless of which outputs ran, and so needed a sha256 stamp file to avoid reloading the shell because a GTK theme was regenerated. A plugin hook is already scoped to its own plugin, so the stamp is unnecessary; but the content check it provided was worth keeping, and belongs here rather than in a hook that cannot see which outputs ran.

## Tests

Unchanged detection across three generates (no file → changed; identical → unchanged; different palette → changed again); `matchesFileOnDisk` including missing file and unreadable path both answering false; the zero value defaulting to reload; empty file list as a no-op; and that `Hooks` no longer declares a reload verb, so the two paths cannot both fire.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV