### PR TITLE
fix(spicetify): update tests to the declarative detection contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,25 @@ jobs:
       - name: Run benchmarks
         run: go test -bench=. -benchmem ./...
 
+      # The contrib plugins are separate Go modules, so the root `./...`
+      # above does not reach them. Without this they were never built or
+      # tested in CI, and a plugin could be broken by a change to the
+      # shared SDK without anything failing.
+      - name: Build and test contrib plugin modules
+        run: |
+          set -euo pipefail
+          failed=0
+          for mod in $(find contrib -name go.mod | sort); do
+            dir="$(dirname "$mod")"
+            echo "::group::$dir"
+            if ! (cd "$dir" && go build ./... && go test ./...); then
+              echo "::error file=$mod::contrib module failed: $dir"
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$failed"
+
   # Lint job - runs on all pushes and PRs
   lint:
     name: Lint

--- a/contrib/plugins/output/spicetify/plugin_test.go
+++ b/contrib/plugins/output/spicetify/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -136,46 +137,51 @@ func TestPlugin_GetFlagHelp(t *testing.T) {
 	}
 }
 
-func TestPlugin_PreExecute_NoSpicetify(t *testing.T) {
-	// Restrict PATH so `spicetify` cannot be found.
-	t.Setenv("PATH", "/nonexistent")
+// Detection moved onto the declarative hooks.Spec: the shared runner
+// evaluates RequiredBinaries before PreExecute is reached, so PreExecute
+// itself must no longer gate. Two gates would be able to disagree.
+func TestPlugin_HooksRequireSpicetify(t *testing.T) {
+	spec := (&Plugin{}).Hooks()
 
-	p := &Plugin{}
-	skip, reason, err := p.PreExecute(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !slices.Contains(spec.RequiredBinaries, "spicetify") {
+		t.Errorf("RequiredBinaries = %v, want it to contain spicetify", spec.RequiredBinaries)
 	}
-	if !skip {
-		t.Error("expected skip=true when spicetify is not on PATH")
-	}
-	if !strings.Contains(reason, "spicetify") || !strings.Contains(reason, "spicetify.app") {
-		t.Errorf("expected reason to reference spicetify and the install URL, got %q", reason)
+
+	// Without spicetify the theme files cannot be applied at all, so the
+	// binary is required rather than optional.
+	if slices.Contains(spec.OptionalBinaries, "spicetify") {
+		t.Error("spicetify is listed as optional; without it the theme cannot be applied")
 	}
 }
 
-func TestPlugin_PreExecute_SpicetifyPresent(t *testing.T) {
-	// Create a fake `spicetify` binary on a temp PATH.
-	tmpDir := t.TempDir()
-	fake := filepath.Join(tmpDir, "spicetify")
-	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("failed to write fake binary: %v", err)
-	}
-	t.Setenv("PATH", tmpDir)
+func TestPlugin_PreExecuteNeverSkips(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent")
 
-	p := &Plugin{}
-	skip, _, err := p.PreExecute(context.Background())
+	skip, reason, err := (&Plugin{}).PreExecute(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if skip {
-		t.Error("expected skip=false when spicetify is present on PATH")
+		t.Errorf("PreExecute skipped (%q); the RequiredBinaries hook owns that decision", reason)
 	}
 }
 
-func TestPlugin_PostExecute_PrintsInstructions(t *testing.T) {
-	p := &Plugin{}
-	// Should not return an error and should never attempt to invoke spicetify.
-	if err := p.PostExecute(context.Background(), []string{"/tmp/color.ini"}); err != nil {
+// The manual-apply guidance moved to Hooks().Instructions, which the host
+// prints in verbose mode after files are written.
+func TestPlugin_InstructionsExplainManualApply(t *testing.T) {
+	got := (&Plugin{}).Hooks().Instructions
+
+	for _, want := range []string{"NOT applied", "Close Spotify", "spicetify apply"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Instructions missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// PostExecute is a no-op: the guidance lives in Hooks().Instructions and
+// `spicetify apply` is deliberately never invoked for the user.
+func TestPlugin_PostExecuteIsNoop(t *testing.T) {
+	if err := (&Plugin{}).PostExecute(context.Background(), []string{"/tmp/color.ini"}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
`TestPlugin_PreExecute_NoSpicetify` still asserted that `PreExecute` skips when spicetify is missing:

```
--- FAIL: TestPlugin_PreExecute_NoSpicetify
    plugin_test.go:149: expected skip=true when spicetify is not on PATH
    plugin_test.go:152: expected reason to reference spicetify and the install URL, got ""
```

805022c (#15) moved that check onto the declarative `hooks.Spec` as `RequiredBinaries`, so `PreExecute` is a no-op and the test has been failing since it merged.

## Why CI didn't catch it

The contrib plugins are **separate Go modules**. The root `go test -race ./...` in the test job never reaches them, so a change to the shared SDK can break any plugin while CI stays green. That is precisely what happened — #15 went in with a red contrib test and five subsequent PRs merged on top of it.

The test job now builds and tests every contrib module, grouped per module so a failure is easy to locate:

```yaml
- name: Build and test contrib plugin modules
  run: |
    for mod in $(find contrib -name go.mod | sort); do
      dir="$(dirname "$mod")"
      echo "::group::$dir"
      if ! (cd "$dir" && go build ./... && go test ./...); then
        echo "::error file=$mod::contrib module failed: $dir"
        failed=1
      fi
      echo "::endgroup::"
    done
    exit "$failed"
```

Dry-run locally across all 12 modules: all green, exit 0.

## Replacement tests

Assert the contract that actually exists rather than the one that used to:

- `RequiredBinaries` lists spicetify — and **required**, not optional, since without the CLI the theme files cannot be applied at all
- `PreExecute` never gates, so the two checks cannot disagree
- the manual-apply guidance lives in `Hooks().Instructions`

`TestPlugin_PreExecute_SpicetifyPresent` is dropped with it: `PreExecute` no longer makes that decision in either direction, so the test asserted nothing. `TestPlugin_PostExecute_PrintsInstructions` is renamed to `TestPlugin_PostExecuteIsNoop`, which is what it now verifies.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV