### PR TITLE
ci(deps): bump github actions to current majors

### DIFF
--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -42,7 +42,7 @@ jobs:
           echo "Tag format valid: $TAG"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           lfs: true
@@ -56,7 +56,7 @@ jobs:
           echo "Tag exists: ${{ inputs.tag }}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,14 +46,14 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           lfs: true
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -64,7 +64,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.out
           flags: unittests
@@ -100,10 +100,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.26.x"
           cache: true
@@ -135,16 +135,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.26.x"
           cache: true
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.26.1
+        uses: securego/gosec@v2.29.0
         with:
           args: "-fmt sarif -out gosec-results.sarif -no-fail ./..."
         continue-on-error: true
@@ -195,13 +195,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.26.x"
           cache: true
@@ -368,12 +368,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.26.x"
           cache: true
@@ -484,14 +484,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           lfs: true
           ref: main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
| action | was | now |
|---|---|---|
| `actions/checkout` | v6 | **v7** (8 uses) |
| `actions/setup-go` | v6 | **v7** (5 uses) |
| `actions/setup-node` | v6 | **v7** (2 uses) |
| `codecov/codecov-action` | v6 | **v7** |
| `securego/gosec` | v2.26.1 | v2.29.0 |

Left alone deliberately:

- `golangci/golangci-lint-action@v9` and `goreleaser/goreleaser-action@v7` track moving major tags, so they already resolve to the current release (v9.3.0 / v7.2.3).
- `anchore/sbom-action/download-syft@v0.24.0` is the latest release.

Kept separate from #18 because major action upgrades are the most likely thing in this batch to break CI, and isolating them makes any failure trivially attributable. This PR's own CI run is the test.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV