### PR TITLE
fix: resolve lint regressions introduced this cycle

### DIFF
--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -963,9 +963,8 @@ func registerExternalPluginsFromManifest(manifest *PluginManifest, resolveAbsolu
 			// An outdated plugin is always worth reporting: it silently
 			// disappears from the registry, so the user would otherwise
 			// only see "unknown plugin" and chase the wrong problem.
-			var incompatible *manager.IncompatiblePluginError
-			if errors.As(err, &incompatible) {
-				fmt.Fprintf(os.Stderr, "⊘ Skipping plugin %q: %v\n", meta.Name, err)
+			if incompatible, ok := errors.AsType[*manager.IncompatiblePluginError](err); ok {
+				fmt.Fprintf(os.Stderr, "⊘ Skipping plugin %q: %v\n", meta.Name, incompatible)
 				fmt.Fprintf(os.Stderr, "   Update it with: tinct plugins update %s\n", meta.Name)
 				continue
 			}

--- a/internal/plugin/executor/executor.go
+++ b/internal/plugin/executor/executor.go
@@ -195,28 +195,32 @@ func (e *PluginExecutor) Validate(ctx context.Context, pluginRole string, args m
 // verbose) into the plugin before any other lifecycle call, so
 // PreExecute and GetHooks can honour flags rather than assume defaults.
 //
-// kind selects the client ("input" or "output"). Failure is deliberately
-// swallowed: a plugin that cannot be configured — old SDK, no
+// kind selects the client ("input" or "output"). A returned error is
+// never fatal: a plugin that cannot be configured — old SDK, no
 // Configurable implementation, JSON stdio, or a transport hiccup — must
 // still run, it just sees its args later, in Generate, as it always did.
-func (e *PluginExecutor) Configure(ctx context.Context, kind string, req plugin.ConfigureRequest) {
+// It is returned rather than swallowed so the caller can surface it in
+// verbose mode instead of the failure being invisible.
+func (e *PluginExecutor) Configure(ctx context.Context, kind string, req plugin.ConfigureRequest) error {
 	if e.protocolType != protocol.PluginTypeGoPlugin {
-		return
+		return nil
 	}
 
 	switch kind {
 	case "input":
 		client, err := e.getInputRPCClient(ctx)
 		if err != nil {
-			return
+			return err
 		}
-		_ = client.Configure(req)
+		return client.Configure(req)
 	case "output":
 		client, err := e.getOutputRPCClient(ctx)
 		if err != nil {
-			return
+			return err
 		}
-		_ = client.Configure(req)
+		return client.Configure(req)
+	default:
+		return fmt.Errorf("unknown plugin kind %q", kind)
 	}
 }
 

--- a/internal/plugin/executor/executor_test.go
+++ b/internal/plugin/executor/executor_test.go
@@ -544,3 +544,50 @@ func copyTestScript(t *testing.T, scriptName string) string {
 
 	return pluginPath
 }
+
+// --- Configure -------------------------------------------------------------
+
+// Configure returns its error rather than swallowing it, so a failure to
+// hand a plugin its args is diagnosable instead of silent. It stays
+// non-fatal at the call site, but the executor must not hide it.
+func TestConfigureReturnsErrorForUnknownKind(t *testing.T) {
+	pluginPath := copyTestScript(t, "basic-input.sh")
+	executor, err := NewWithVerbose(pluginPath, false)
+	if err != nil {
+		t.Fatalf("Failed to create executor: %v", err)
+	}
+	defer executor.Close()
+
+	// Force the go-plugin branch so the kind switch is reached; a JSON
+	// stdio executor returns early before it.
+	executor.protocolType = protocol.PluginTypeGoPlugin
+
+	err = executor.Configure(context.Background(), "bogus", plugin.ConfigureRequest{})
+	if err == nil {
+		t.Fatal("Configure accepted an unknown plugin kind")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error %q, want it to name the offending kind", err.Error())
+	}
+}
+
+// JSON-stdio plugins have no Configure RPC; the call is a no-op rather
+// than an error, so those plugins keep working untouched.
+func TestConfigureIsNoOpForJSONStdio(t *testing.T) {
+	pluginPath := copyTestScript(t, "basic-input.sh")
+	executor, err := NewWithVerbose(pluginPath, false)
+	if err != nil {
+		t.Fatalf("Failed to create executor: %v", err)
+	}
+	defer executor.Close()
+
+	if executor.protocolType != protocol.PluginTypeJSON {
+		t.Skipf("fixture is not a JSON stdio plugin (got %v)", executor.protocolType)
+	}
+
+	for _, kind := range []string{"input", "output", "bogus"} {
+		if err := executor.Configure(context.Background(), kind, plugin.ConfigureRequest{}); err != nil {
+			t.Errorf("Configure(%q) returned %v, want nil for a JSON stdio plugin", kind, err)
+		}
+	}
+}

--- a/internal/plugin/manager/manager.go
+++ b/internal/plugin/manager/manager.go
@@ -370,11 +370,17 @@ func (b *externalPluginBase) session(kind string) (*executor.PluginExecutor, err
 
 	if !b.configured {
 		b.configured = true
-		pluginExec.Configure(context.Background(), kind, plugin.ConfigureRequest{
+		cfgErr := pluginExec.Configure(context.Background(), kind, plugin.ConfigureRequest{
 			Args:    b.args,
 			DryRun:  b.dryRun,
 			Verbose: b.verbose,
 		})
+		// Non-fatal by design — the plugin still generates, it just sees
+		// its args later, in Generate. Surfaced in verbose mode so the
+		// failure is diagnosable rather than silent.
+		if cfgErr != nil && b.verbose {
+			fmt.Fprintf(os.Stderr, "   %s: configure failed: %v\n", b.name, cfgErr)
+		}
 	}
 
 	return b.execSession, nil

--- a/pkg/plugin/rpc_test.go
+++ b/pkg/plugin/rpc_test.go
@@ -102,10 +102,10 @@ func TestInputPluginRPC(t *testing.T) {
 		},
 	}
 
-	rpc := &InputPluginRPC{Impl: mock}
+	rpcPlugin := &InputPluginRPC{Impl: mock}
 
 	t.Run("Server", func(t *testing.T) {
-		server, err := rpc.Server(nil)
+		server, err := rpcPlugin.Server(nil)
 		if err != nil {
 			t.Fatalf("Server() error = %v", err)
 		}
@@ -123,7 +123,7 @@ func TestInputPluginRPC(t *testing.T) {
 	})
 
 	t.Run("Client", func(t *testing.T) {
-		client, err := rpc.Client(nil, nil)
+		client, err := rpcPlugin.Client(nil, nil)
 		if err != nil {
 			t.Fatalf("Client() error = %v", err)
 		}
@@ -152,10 +152,10 @@ func TestOutputPluginRPC(t *testing.T) {
 		},
 	}
 
-	rpc := &OutputPluginRPC{Impl: mock}
+	rpcPlugin := &OutputPluginRPC{Impl: mock}
 
 	t.Run("Server", func(t *testing.T) {
-		server, err := rpc.Server(nil)
+		server, err := rpcPlugin.Server(nil)
 		if err != nil {
 			t.Fatalf("Server() error = %v", err)
 		}
@@ -173,7 +173,7 @@ func TestOutputPluginRPC(t *testing.T) {
 	})
 
 	t.Run("Client", func(t *testing.T) {
-		client, err := rpc.Client(nil, nil)
+		client, err := rpcPlugin.Client(nil, nil)
 		if err != nil {
 			t.Fatalf("Client() error = %v", err)
 		}
@@ -469,8 +469,9 @@ func (s *slowService) Hang(_ string, reply *string) error {
 }
 
 // newLoopbackClient serves slowService over an in-memory pipe and
-// returns a connected rpc.Client.
-func newLoopbackClient(t *testing.T) (*rpc.Client, *slowService) {
+// returns a connected rpc.Client. The service itself is released by the
+// cleanup below, so callers never need a handle on it.
+func newLoopbackClient(t *testing.T) *rpc.Client {
 	t.Helper()
 
 	svc := &slowService{release: make(chan struct{})}
@@ -487,12 +488,12 @@ func newLoopbackClient(t *testing.T) (*rpc.Client, *slowService) {
 		close(svc.release)
 		_ = client.Close()
 	})
-	return client, svc
+	return client
 }
 
 // A responsive method returns its reply and no error.
 func TestCallReturnsReply(t *testing.T) {
-	client, _ := newLoopbackClient(t)
+	client := newLoopbackClient(t)
 
 	var got string
 	if err := call(client, "Plugin.Echo", "hello", &got, callTimeout); err != nil {
@@ -506,7 +507,7 @@ func TestCallReturnsReply(t *testing.T) {
 // The regression this exists for: a method that never replies must fail
 // on a deadline rather than block the host forever.
 func TestCallTimesOutInsteadOfHanging(t *testing.T) {
-	client, _ := newLoopbackClient(t)
+	client := newLoopbackClient(t)
 
 	done := make(chan error, 1)
 	go func() {
@@ -532,7 +533,7 @@ func TestCallTimesOutInsteadOfHanging(t *testing.T) {
 // A missing method must surface as an error call() passes through, so
 // isMissingMethodErr can classify it for the optional-RPC fallbacks.
 func TestCallSurfacesMissingMethod(t *testing.T) {
-	client, _ := newLoopbackClient(t)
+	client := newLoopbackClient(t)
 
 	var got string
 	err := call(client, "Plugin.NoSuchMethod", "x", &got, callTimeout)


### PR DESCRIPTION
`golangci-lint` reports **43** issues on `main` against **37** at `bad3b40` (before this cycle's plugin work), so six were introduced by it. CI never objected because the Lint job carries `continue-on-error: true` — addressed separately in a follow-up.

## The six

**`executor.go` — errcheck ×2.** `Configure` blanked its error with `_ =`, and the project sets `errcheck.check-blank: true`, deliberately rejecting that. Rather than silencing the linter with a `nolint`, `Configure` now returns the error and `session()` surfaces it in verbose mode:

```go
if cfgErr != nil && b.verbose {
    fmt.Fprintf(os.Stderr, "   %s: configure failed: %v\n", b.name, cfgErr)
}
```

Semantics are unchanged — a plugin that cannot be configured still runs, it just sees its args later in `Generate` — but the failure is now diagnosable instead of invisible, which is exactly what the blank was hiding.

**`rpc_test.go` — gocritic ×2.** Adding the `net/rpc` import turned two pre-existing `rpc := …` locals into shadows of the package name. Renamed to `rpcPlugin`.

**`rpc_test.go` — unparam ×1.** `newLoopbackClient` returned a `*slowService` that no caller used. Dropped.

**`cli/plugin.go` — modernize ×1.** `errors.As` replaced with `errors.AsType`. The typed error is now used in the message rather than blanked — blanking it tripped `check-blank`, since the value is itself an `error`.

## Verification

Linted `bad3b40` in a worktree with the same golangci-lint build (2.13.1, matching what CI's `version: latest` installs):

```
baseline bad3b40 : 37 issues  (goconst 34, gosec 1, modernize 1, nolintlint 1)
main before      : 43 issues
main after       : 37 issues  (identical composition to baseline)
```

The remaining 37 are pre-existing and are not touched here — they get their own PR, since mixing "undo my regressions" with "clean up a long-standing backlog" would make both harder to review.

`go build`, `go vet`, `gofmt` and `go test ./...` all clean.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV