### PR TITLE
fix(release): build and publish the noctalia and spicetify plugins

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -456,6 +456,72 @@ builds:
 
     mod_timestamp: "{{ .CommitTimestamp }}"
 
+  - id: tinct-plugin-noctalia
+    main: .
+    binary: tinct-plugin-noctalia
+    dir: ./contrib/plugins/output/noctalia
+
+    # Build for Linux only (Noctalia is a Wayland shell, Linux-only)
+    goos:
+      - linux
+
+    goarch:
+      - amd64
+      - arm64
+      - arm
+
+    goarm:
+      - "7"
+
+    # Build flags
+    env:
+      - CGO_ENABLED=0
+
+    flags:
+      - -trimpath
+      - -mod=mod
+
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.Commit={{.Commit}}
+      - -X main.Date={{.Date}}
+
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+  - id: tinct-plugin-spicetify
+    main: .
+    binary: tinct-plugin-spicetify
+    dir: ./contrib/plugins/output/spicetify
+
+    # Build for Linux only (matches the other contrib plugins)
+    goos:
+      - linux
+
+    goarch:
+      - amd64
+      - arm64
+      - arm
+
+    goarm:
+      - "7"
+
+    # Build flags
+    env:
+      - CGO_ENABLED=0
+
+    flags:
+      - -trimpath
+      - -mod=mod
+
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.Commit={{.Commit}}
+      - -X main.Date={{.Date}}
+
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
 # ============================================================================
 # ARCHIVES
 # ============================================================================
@@ -732,6 +798,50 @@ archives:
       - src: contrib/plugins/output/ptyxis/README.md
         dst: README.md
       - src: contrib/plugins/output/ptyxis/templates/*.tmpl
+        dst: templates/
+      - src: LICENSE
+        dst: LICENSE
+
+  - id: tinct-plugin-noctalia-archive
+    ids:
+      - tinct-plugin-noctalia
+    name_template: >-
+      tinct-plugin-noctalia_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+    formats: [tar.gz]
+
+    files:
+      - src: contrib/plugins/output/noctalia/README.md
+        dst: README.md
+      - src: contrib/plugins/output/noctalia/templates/*.tmpl
+        dst: templates/
+      - src: LICENSE
+        dst: LICENSE
+
+  - id: tinct-plugin-spicetify-archive
+    ids:
+      - tinct-plugin-spicetify
+    name_template: >-
+      tinct-plugin-spicetify_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+    formats: [tar.gz]
+
+    files:
+      - src: contrib/plugins/output/spicetify/README.md
+        dst: README.md
+      - src: contrib/plugins/output/spicetify/templates/*.tmpl
         dst: templates/
       - src: LICENSE
         dst: LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,40 +13,34 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Input plugins must now speak protocol `0.2.0` or newer. `WallpaperRawPath` was added after the `0.1.0` bump but before `0.2.0`, so a `0.1.0` input plugin may not implement it — and the host calls it unconditionally, where an absent method blocked the run indefinitely rather than erroring. Older input plugins are refused at registration with a message naming the gap; run `tinct plugins update <name>`. Output plugins are unaffected and keep the `0.0.1` floor: every RPC the host calls on them unconditionally predates `0.1.0`.
+
 ### Added
 
+- The `noctalia` and `spicetify` plugins are now built and published with releases. Both existed only as source before, so `tinct plugins install noctalia` could never succeed.
 - `hooks.Spec.RequiredAny` — a satisfied-by-any detection group (`AnyOf{Binaries, Dirs, Reason}`). Groups are ANDed, entries within a group ORed, so plugins whose app has more than one valid install shape no longer need a hand-rolled `PreExecute`. Paths are checked with `os.Stat`, so plain files (`kdeglobals`, `config.toml`) count as markers; binaries still resolve through appdetect (PATH/Flatpak/AppImage). An optional per-group `Reason` replaces the generated skip message.
 - Multi-line skip reasons and `Instructions` are formatted by the hook runner. `hooks.Indent` dedents continuation lines and re-indents them under the header, preserving relative nesting so a command indented under a numbered step stays indented.
 - Optional `Configurable` plugin interface and `Plugin.Configure` RPC. The host pushes args, dry-run and verbose into a plugin before the pre-execute lifecycle, so `PreExecute` and `Hooks` can honour flags instead of assuming defaults. Plugins that do not implement it are unaffected — unknown-method errors fall back like `Validate` and `GetHooks`.
 
 ### Changed
 
-- kde-plasma, rosec, qt5, qt6 and spicetify move their installation detection (and, for spicetify, the manual-apply message) off hand-rolled `PreExecute`/`PostExecute` onto the declarative `hooks.Spec`.
-- External plugins keep one subprocess for a whole run instead of spawning a fresh one per RPC. A full generate went from ~25 plugin launches to 3 (5 to 1 for a single-plugin run), which also all but removes the stray `yamux: Failed to write header` lines those teardowns produced.
-
-### Changed
-
+- External plugins keep one subprocess for a whole run instead of spawning a fresh one per RPC. A full generate went from roughly 25 plugin launches to 3 (5 to 1 for a single-plugin run), which also all but removes the stray `yamux: Failed to write header` lines those teardowns produced.
 - The noctalia plugin skips the shell reload when the regenerated palette is byte-identical to the one already on disk. A reload makes Noctalia re-read its whole config tree, which is wasted work when the colours have not moved — regenerating from the same wallpaper now costs nothing.
+- kde-plasma, rosec, qt5, qt6 and spicetify move their installation detection (and, for spicetify, the manual-apply message) off hand-rolled `PreExecute`/`PostExecute` onto the declarative `hooks.Spec`.
+- CI now builds and tests the contrib plugin modules, and the lint, `go vet` and formatting steps can actually fail. They carried `continue-on-error`, so the Lint job reported success while printing `##[error]issues found`.
 
 ### Fixed
 
-- `--noctalia.output-dir` was accepted and silently ignored — the plugin never read `PaletteData.PluginArgs` and its output directory was never assigned. It now arrives via `Configure` before `Hooks`/`PreExecute`, expands `~`, and suppresses the config-directory check when set.
-- External input plugins no longer lose their debug output under `--verbose`. Verbose is set on the plugin before `Validate`, which is the first RPC and therefore the call that starts the subprocess whose logger is fixed for its lifetime.
-
-- The noctalia output plugin now reloads the running shell after writing the palette. Noctalia does not watch `~/.config/noctalia/palettes/` — its inotify watch is non-recursive and only reacts to `*.toml` — so a regenerated palette never reached the running shell and the colours stayed as they were at startup. The plugin declares a `hooks.Spec` reload running `noctalia msg config-reload`, with `noctalia` as an optional binary.
-
-- `tinct plugins update <name>` now updates only the named plugin. The command declared no positional arguments and never read them, so cobra accepted the name, discarded it, and updated every plugin in the manifest. An unknown name is now an error listing what is installed, rather than a silent full update.
-- `tinct plugins update` can update plugins added from a local path. Local sources record their origin in `source.original_path`, which the update path never consulted — so every plugin installed with `tinct plugins add ./binary` reported "No source information" and could never be updated.
-
-### Breaking changes
-
-- Input plugins must now speak protocol `0.2.0` or newer. `WallpaperRawPath` was added after the `0.1.0` bump but before `0.2.0`, so a `0.1.0` input plugin may not implement it — and the host calls it unconditionally. Older input plugins are refused at registration with a message naming the gap; run `tinct plugins update <name>`. Output plugins are unaffected and keep the `0.0.1` floor: every RPC the host calls on them unconditionally predates `0.1.0`.
-
-### Fixed
-
-- Plugin RPCs are now bounded by a deadline. `net/rpc` has no timeouts, so a plugin that never answers hung tinct indefinitely with no output and nothing to diagnose — reachable in practice via an outdated plugin missing a method the host calls unconditionally. Metadata-style calls get 30s; `Generate` gets 10 minutes, since an input plugin may legitimately be waiting on remote image generation.
+- The noctalia output plugin now reloads the running shell after writing the palette. Noctalia does not watch `~/.config/noctalia/palettes/` — its inotify watch is non-recursive and only reacts to `*.toml` — so a regenerated palette never reached the running shell and the colours stayed as they were at startup. The plugin runs `noctalia msg config-reload`, with `noctalia` as an optional binary.
+- Plugin RPCs are now bounded by a deadline. `net/rpc` has no timeouts, so a plugin that never answers hung tinct indefinitely with no output and nothing to diagnose. Metadata-style calls get 30s; `Generate` gets 10 minutes, since an input plugin may legitimately be waiting on remote image generation.
 - The protocol floor is enforced rather than nominal. `MinCompatibleVersion` was `0.0.1` while the only other rule was "major version must match", so every `0.x` plugin ever built passed and the gate never fired.
 - An outdated plugin is reported without `--verbose`. It was rejected silently, leaving `unknown plugin: <name>` as the only symptom, which points at entirely the wrong problem.
+- `tinct plugins update <name>` now updates only the named plugin. The command declared no positional arguments and never read them, so cobra accepted the name, discarded it, and updated every plugin in the manifest. An unknown name is now an error listing what is installed, rather than a silent full update.
+- `tinct plugins update` can update plugins added from a local path. Local sources record their origin in `source.original_path`, which the update path never consulted — so every plugin installed with `tinct plugins add ./binary` reported "No source information" and could never be updated.
+- `--noctalia.output-dir` was accepted and silently ignored — the plugin never read `PaletteData.PluginArgs` and its output directory was never assigned. It now arrives via `Configure` before `Hooks`/`PreExecute`, expands `~`, and suppresses the config-directory check when set.
+- External input plugins no longer lose their debug output under `--verbose`. Verbose is set on the plugin before `Validate`, which is the first RPC and therefore the call that starts the subprocess whose logger is fixed for its lifetime.
 
 ## [0.4.2]
 *2026-08-14*

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -13,6 +13,35 @@ and this project adheres to [Conventional Commits](https://www.conventionalcommi
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Input plugins must now speak protocol `0.2.0` or newer. `WallpaperRawPath` was added after the `0.1.0` bump but before `0.2.0`, so a `0.1.0` input plugin may not implement it — and the host calls it unconditionally, where an absent method blocked the run indefinitely rather than erroring. Older input plugins are refused at registration with a message naming the gap; run `tinct plugins update <name>`. Output plugins are unaffected and keep the `0.0.1` floor: every RPC the host calls on them unconditionally predates `0.1.0`.
+
+### Added
+
+- The `noctalia` and `spicetify` plugins are now built and published with releases. Both existed only as source before, so `tinct plugins install noctalia` could never succeed.
+- `hooks.Spec.RequiredAny` — a satisfied-by-any detection group (`AnyOf{Binaries, Dirs, Reason}`). Groups are ANDed, entries within a group ORed, so plugins whose app has more than one valid install shape no longer need a hand-rolled `PreExecute`. Paths are checked with `os.Stat`, so plain files (`kdeglobals`, `config.toml`) count as markers; binaries still resolve through appdetect (PATH/Flatpak/AppImage). An optional per-group `Reason` replaces the generated skip message.
+- Multi-line skip reasons and `Instructions` are formatted by the hook runner. `hooks.Indent` dedents continuation lines and re-indents them under the header, preserving relative nesting so a command indented under a numbered step stays indented.
+- Optional `Configurable` plugin interface and `Plugin.Configure` RPC. The host pushes args, dry-run and verbose into a plugin before the pre-execute lifecycle, so `PreExecute` and `Hooks` can honour flags instead of assuming defaults. Plugins that do not implement it are unaffected — unknown-method errors fall back like `Validate` and `GetHooks`.
+
+### Changed
+
+- External plugins keep one subprocess for a whole run instead of spawning a fresh one per RPC. A full generate went from roughly 25 plugin launches to 3 (5 to 1 for a single-plugin run), which also all but removes the stray `yamux: Failed to write header` lines those teardowns produced.
+- The noctalia plugin skips the shell reload when the regenerated palette is byte-identical to the one already on disk. A reload makes Noctalia re-read its whole config tree, which is wasted work when the colours have not moved — regenerating from the same wallpaper now costs nothing.
+- kde-plasma, rosec, qt5, qt6 and spicetify move their installation detection (and, for spicetify, the manual-apply message) off hand-rolled `PreExecute`/`PostExecute` onto the declarative `hooks.Spec`.
+- CI now builds and tests the contrib plugin modules, and the lint, `go vet` and formatting steps can actually fail. They carried `continue-on-error`, so the Lint job reported success while printing `##[error]issues found`.
+
+### Fixed
+
+- The noctalia output plugin now reloads the running shell after writing the palette. Noctalia does not watch `~/.config/noctalia/palettes/` — its inotify watch is non-recursive and only reacts to `*.toml` — so a regenerated palette never reached the running shell and the colours stayed as they were at startup. The plugin runs `noctalia msg config-reload`, with `noctalia` as an optional binary.
+- Plugin RPCs are now bounded by a deadline. `net/rpc` has no timeouts, so a plugin that never answers hung tinct indefinitely with no output and nothing to diagnose. Metadata-style calls get 30s; `Generate` gets 10 minutes, since an input plugin may legitimately be waiting on remote image generation.
+- The protocol floor is enforced rather than nominal. `MinCompatibleVersion` was `0.0.1` while the only other rule was "major version must match", so every `0.x` plugin ever built passed and the gate never fired.
+- An outdated plugin is reported without `--verbose`. It was rejected silently, leaving `unknown plugin: <name>` as the only symptom, which points at entirely the wrong problem.
+- `tinct plugins update <name>` now updates only the named plugin. The command declared no positional arguments and never read them, so cobra accepted the name, discarded it, and updated every plugin in the manifest. An unknown name is now an error listing what is installed, rather than a silent full update.
+- `tinct plugins update` can update plugins added from a local path. Local sources record their origin in `source.original_path`, which the update path never consulted — so every plugin installed with `tinct plugins add ./binary` reported "No source information" and could never be updated.
+- `--noctalia.output-dir` was accepted and silently ignored — the plugin never read `PaletteData.PluginArgs` and its output directory was never assigned. It now arrives via `Configure` before `Hooks`/`PreExecute`, expands `~`, and suppresses the config-directory check when set.
+- External input plugins no longer lose their debug output under `--verbose`. Verbose is set on the plugin before `Validate`, which is the first RPC and therefore the call that starts the subprocess whose logger is fixed for its lifetime.
+
 ## [0.4.2]
 *2026-08-14*
 


### PR DESCRIPTION
## noctalia and spicetify were never released

```
released      awob, dunstify, keylightd-tray, opencode, paletty,
              ptyxis, random, templater, wob, zed
NOT RELEASED  noctalia, spicetify
```

Neither had a `.goreleaser.yml` entry, so both shipped as source only. `144bddc` added noctalia in 0.4.2 with README, `go.mod` and `plugin.go` — and no build config. Spicetify has been in the same state since 0.3.3.

The noctalia README documents `tinct plugins install noctalia` as the install method. That has never worked: the only way to obtain it is to clone the repo and build it, which is exactly why a local install records `source.type=local` pointing at a working tree.

Cutting 0.5.0 without this would ship a release headlined by noctalia fixes that nobody can install.

## Changes

Build and archive blocks for both, matching the existing contrib plugins: Linux-only, same arch matrix (amd64/arm64/arm v7), `CGO_ENABLED=0`, `-trimpath`, ldflags injecting version/commit/date, and an archive carrying README, `templates/*.tmpl` and LICENSE.

Verified:

```
$ goreleaser check
  • 1 configuration file(s) validated

$ goreleaser build --snapshot --single-target --id tinct-plugin-noctalia --id tinct-plugin-spicetify
  • build succeeded after 13s

$ ./dist/.../tinct-plugin-noctalia --version
tinct-plugin-noctalia 0.4.3-preview.1787877860+8e6ed6e
```

The injected version confirms the ldflags wire up — released binaries will report `0.5.0`, not their hardcoded defaults.

## Changelog consolidation

`[Unreleased]` had accumulated duplicate `### Changed` and `### Fixed` headings and a `### Breaking changes` block buried mid-section, after twelve merges each appending to it. `promote-unreleased.sh` copies that block **verbatim** into the release notes, so it is now one ordered set with the breaking change first, plus entries for the CI gaps closed this cycle.

Dry-run of the promotion produces a clean `## [0.5.0]` section, with the auto-generated conventional-commit bullets appended beneath — correctly categorised and with `chore(deps)`/`ci(deps)` filtered out.

https://claude.ai/code/session_01ExXboHPKfvG2pkraN7wnuV